### PR TITLE
allow duplicate ids in node bindings

### DIFF
--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -40,8 +40,6 @@ async def normalize_results(
         for node_code, node_bindings in result.node_bindings.items():
             merged_node_bindings = []
             for n_bind in node_bindings:
-                if node_id_map[n_bind.id.__root__] in nodes_seen:
-                    continue
                 merged_binding = n_bind.dict()
                 merged_binding['id'] = node_id_map[n_bind.id.__root__]
                 merged_node_bindings.append(merged_binding)


### PR DESCRIPTION
Reverting the node binding behavior introduced in #45, as this results in an empty list in some cases.  With this change we will allow an ID to be in >=1 node bindings.

See #46 