### PR TITLE
better handling/merging of attributes and extra fields

### DIFF
--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -1,8 +1,10 @@
 import json
 from typing import List, Dict, Optional, Any, Set, Tuple, Union
+import uuid
+from uuid import UUID
 
 from fastapi import FastAPI
-from reasoner_pydantic import KnowledgeGraph, Message, QueryGraph, Result, CURIE
+from reasoner_pydantic import KnowledgeGraph, Message, QueryGraph, Result, CURIE, Attribute
 
 
 async def normalize_message(app: FastAPI, message: Message) -> Message:
@@ -30,34 +32,46 @@ async def normalize_results(
     Given a TRAPI result creates a normalized result object
     """
     merged_results: List[Result] = []
+    result_seen = set()
     for result in results:
         merged_result = {
             'node_bindings': {},
             'edge_bindings': {}
         }
-        nodes_seen = set()
-        edges_seen = set()
+
         for node_code, node_bindings in result.node_bindings.items():
             merged_node_bindings = []
             for n_bind in node_bindings:
-                if node_id_map[n_bind.id.__root__] in nodes_seen:
-                    continue
                 merged_binding = n_bind.dict()
                 merged_binding['id'] = node_id_map[n_bind.id.__root__]
                 merged_node_bindings.append(merged_binding)
-                nodes_seen.add(node_id_map[n_bind.id.__root__])
             merged_result['node_bindings'][node_code] = merged_node_bindings
 
         for edge_code, edge_bindings in result.edge_bindings.items():
             merged_edge_bindings = []
             for e_bind in edge_bindings:
-                if edge_id_map[e_bind.id] in edges_seen:
-                    continue
                 merged_binding = e_bind.dict()
                 merged_binding['id'] = edge_id_map[e_bind.id]
                 merged_edge_bindings.append(merged_binding)
-                edges_seen.add(edge_id_map[e_bind.id])
             merged_result['edge_bindings'][edge_code] = merged_edge_bindings
+
+        try:
+            result_tuple = tuple(
+                (k, tuple(v))
+                if isinstance(v, list)
+                else (k,v)
+                for k,v in merged_result.items()
+            )
+            hashed_result = hash(result_tuple)
+
+        except Exception:  # TODO determine exception(s) to catch
+            hashed_result = False
+
+        if hashed_result is not False:
+            if hashed_result in result_seen:
+                continue
+            else:
+                result_seen.add(hashed_result)
 
         merged_results.append(Result.parse_obj(merged_result))
 
@@ -131,16 +145,19 @@ async def normalize_kgraph(
     edge_id_map: Dict[str,str] = {}
 
     # Map for each edge to its s,p,r,o signature
-    primary_edges: Dict[Tuple[str, str, str, str], str] = {}
+    primary_edges: Dict[Tuple[str, str, Optional[str], str, Union[UUID, int]], str] = {}
 
     # cache for primary node ids
     primary_nodes_seen = set()
 
+    # Count of times a node has been merged for attribute merging
+    node_merge_count: Dict[str, int] = {}
+
     # cache for nodes
     nodes_seen = set()
 
-    # cache for subject, predicate, relation, object tuples
-    edges_seen: Set[Tuple[str, str, str, str]] = set()
+    # cache for subject, predicate, relation, object, attribute hash tuples
+    edges_seen: Set[Tuple[str, str, str, str, Union[UUID, int]]] = set()
 
     for node_id, node in kgraph.nodes.items():
         if node_id in nodes_seen:
@@ -158,8 +175,16 @@ async def normalize_kgraph(
             node_id_map[node_id] = primary_id
 
             if primary_id in primary_nodes_seen:
-                # TODO attribute merging
+                merged_node = _merge_node_attributes(
+                    node_a=merged_kgraph['nodes'][primary_id],
+                    node_b=node.dict(),
+                    merged_count=node_merge_count[primary_id]
+                )
+                merged_kgraph['nodes'][primary_id] = merged_node
+                node_merge_count[primary_id] += 1
                 continue
+            else:
+                node_merge_count[primary_id] = 0
 
             primary_nodes_seen.add(primary_id)
 
@@ -172,25 +197,28 @@ async def normalize_kgraph(
 
             merged_node['name'] = primary_label
 
-            # TODO define behavior if there is already a same_as attribute
+            # Even if there's already a same_as attribute we add another
+            # since it is coming from a new source
             if 'equivalent_identifiers' in equivalent_curies[node_id]:
-                merged_node['attributes'] = [
-                    {
-                        'type': 'biolink:same_as',
-                        'value': [
-                            node['identifier']
-                            for node in equivalent_curies[node_id]['equivalent_identifiers']
-                        ],
-                        'name': 'same_as',
+                same_as_attribute = {
+                    'type': 'biolink:same_as',
+                    'value': [
+                        node['identifier']
+                        for node in equivalent_curies[node_id]['equivalent_identifiers']
+                    ],
+                    'name': 'same_as',
 
-                        # TODO, should we add the app version as the source
-                        # or perhaps the babel/redis cache version
-                        # This will make unit testing a little more tricky
-                        # see https://stackoverflow.com/q/57624731
+                    # TODO, should we add the app version as the source
+                    # or perhaps the babel/redis cache version
+                    # This will make unit testing a little more tricky
+                    # see https://stackoverflow.com/q/57624731
 
-                        # 'source': f'{app.title} {app.version}',
-                    }
-                ]
+                    # 'source': f'{app.title} {app.version}',
+                }
+                if 'attributes' in merged_node and merged_node['attributes']:
+                    merged_node['attributes'].append(same_as_attribute)
+                else:
+                    merged_node['attributes'] = [same_as_attribute]
 
             if 'type' in equivalent_curies[node_id]:
                 merged_node['category'] = equivalent_curies[node_id]['type']
@@ -200,11 +228,6 @@ async def normalize_kgraph(
             merged_kgraph['nodes'][node_id] = merged_node
 
     for edge_id, edge in kgraph.edges.items():
-        # TODO, there's ambiguous criteria for when to
-        # merge an edge, for example
-        # initial criteria: s,p,o or s,p,o,r
-        # handling attributes if the above is met
-
         # Accessing __root__ directly seems wrong,
         # https://github.com/samuelcolvin/pydantic/issues/730
         # could also do str(edge.subject)
@@ -212,18 +235,25 @@ async def normalize_kgraph(
             primary_subject = node_id_map[edge.subject.__root__]
         else:
             # should we throw a validation error here?
-            primary_subject = edge.subject
+            primary_subject = edge.subject.__root__
 
         if edge.object.__root__ in node_id_map:
             primary_object = node_id_map[edge.object.__root__]
         else:
-            primary_object = edge.object
+            primary_object = edge.object.__root__
+
+        hashed_attributes = _hash_attributes(edge.attributes)
+
+        if hashed_attributes is False:
+            # we couldn't hash the attribute so assume unique
+            hashed_attributes = uuid.uuid4()
 
         triple = (
             primary_subject,
             edge.predicate.__root__,
             edge.relation,
-            primary_object
+            primary_object,
+            hashed_attributes
         )
         if triple in edges_seen:
             edge_id_map[edge_id] = primary_edges[triple]
@@ -337,3 +367,88 @@ async def get_curie_prefixes(
             ret_val[item] = {'curie_prefix': curies}
 
     return ret_val
+
+
+def _merge_node_attributes(node_a: Dict, node_b, merged_count: int) -> Dict:
+    """
+    :param node_a: the primary node
+    :param node_b: the node to be merged
+    :param merged_count: the number of nodes merged into node_a **upon entering this fx**
+    """
+    if not ('attributes' in node_b and node_b['attributes']):
+        return node_a
+
+    if merged_count == 0:
+        if 'attributes' in node_a and node_a['attributes']:
+            new_attribute_list = []
+            for attribute in node_a['attributes']:
+                new_dict = {}
+                for k,v in attribute.items():
+                    new_dict[f"{k}.1"] = v
+                new_attribute_list.append(new_dict)
+
+            node_a['attributes'] = new_attribute_list
+
+    # Need to DRY this off
+    b_attr_id = merged_count + 2
+    if 'attributes' in node_b and node_b['attributes']:
+        new_attribute_list = []
+        for attribute in node_b['attributes']:
+            new_dict = {}
+            for k, v in attribute.items():
+                new_dict[f"{k}.{b_attr_id}"] = v
+            new_attribute_list.append(new_dict)
+
+        node_a['attributes'] = node_a['attributes'] + new_attribute_list
+
+    return node_a
+
+
+def _hash_attributes(attributes: List[Attribute] = None) -> Union[int, bool]:
+    """
+    Attempt to make an attribute list hashable by converting it to a
+    tuple of tuples
+
+    Using the python builtin hash https://docs.python.org/3.5/library/functions.html#hash
+    Which can technically return zero, so downstream code should explicitly check
+    for a False value instead of falsy values
+
+    The tricky thing here is that attribute.value is an Any type, so we do some type
+    checking to see if it's hashable
+    """
+    new_attributes = []
+
+    if not attributes:
+        return hash(attributes)
+
+    for attribute in attributes:
+        hashed_value = attribute.value
+        if attribute.value:
+            try:
+                if isinstance(attribute.value, list):
+                    # TODO list of lists?
+                    hashed_value = tuple(attribute.value)
+                elif isinstance(attribute.value, dict):
+                    hashed_value = tuple(
+                        (k, tuple(v))
+                        if isinstance(v, list)
+                        else (k,v)
+                        for k,v in attribute.value.items())
+            except Exception as e:
+                # TODO figure out what exceptions to catch
+                return False
+
+        new_attribute = (
+            attribute.type.__root__,
+            hashed_value,
+            attribute.name,
+            attribute.url,
+            attribute.source
+        )
+        new_attributes.append(new_attribute)
+
+    try:
+        return hash(tuple(new_attributes))
+    except Exception:
+        # TODO figure out what exceptions to catch
+        return False

--- a/tests/helpers/redis_mocks.py
+++ b/tests/helpers/redis_mocks.py
@@ -14,6 +14,11 @@ async def mock_get_equivalent_curies(app, curie):
     else:
         curie = curie.__root__.replace(':', '_')
     mock_redis = Path(__file__).parent.parent / 'resources' / 'mock-redis' / f'{curie}.json'
-    with open(mock_redis, 'r') as json_data:
-        equivalent_curies = json.load(json_data)
+    if mock_redis.exists():
+        with open(mock_redis, 'r') as json_data:
+            equivalent_curies = json.load(json_data)
+    else:
+        equivalent_curies = {
+            f"{curie}": None
+        }
     return equivalent_curies

--- a/tests/resources/postmerged_dupe_edge.json
+++ b/tests/resources/postmerged_dupe_edge.json
@@ -1,0 +1,113 @@
+{
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "id": "NODE_1",
+          "category": "biolink:Disease",
+          "is_set": false
+        },
+        "n1": {
+          "id": "NODE_2",
+          "category": "biolink:ChemicalSubstance",
+          "is_set": false,
+          "set": true
+        }
+      },
+      "edges": {
+        "e01": {
+          "subject": "n0",
+          "object": "n1",
+          "predicate": "biolink:correlated_with",
+          "relation": null
+        }
+      }
+    },
+    "knowledge_graph": {
+      "nodes": {
+        "NODE_1": {
+          "category": [
+            "biolink:D",
+            "biolink:I",
+            "biolink:S",
+            "biolink:E",
+            "biolink:A",
+            "biolink:S",
+            "biolink:E"
+          ],
+          "name": null,
+          "attributes": null
+        },
+        "NODE_2": {
+          "category": [
+            "biolink:ChemicalSubstance"
+          ],
+          "name": "AvgDailyOzoneExposure,AvgDailyOzoneExposure_StudyAvg,AvgDailyOzoneExposure_StudyMax,MaxDailyOzoneExposure,MaxDailyOzoneExposure_StudyAvg,MaxDailyOzoneExposure_StudyMax,AvgDailyOzoneExposure_qcut,AvgDailyOzoneExposure_StudyAvg_qcut,AvgDailyOzoneExposure_StudyMax_qcut,MaxDailyOzoneExposure_qcut,MaxDailyOzoneExposure_StudyAvg_qcut,MaxDailyOzoneExposure_StudyMax_qcut,MaxDailyOzoneExposure_2,MaxDailyOzoneExposure_2_qcut",
+          "attributes": [
+            {
+              "type": "EDAM:data_0006",
+              "value": [
+                "PUBCHEM:24823",
+                "SCTID:40057008",
+                "NODE_2",
+                "ENVO:01000537"
+              ],
+              "name": "equivalent_identifiers",
+              "url": null,
+              "source": null
+            }
+          ]
+        }
+      },
+      "edges": {
+        "EDGE_1": {
+          "subject": "NODE_1",
+          "object": "NODE_2",
+          "predicate": "biolink:correlated_with",
+          "relation": null,
+          "attributes": [
+            {
+              "type": "MetaInformation",
+              "value": "https://icees.renci.org:16339/knowledge_graph_one_hop?reasoner=true",
+              "name": "provenance",
+              "url": null,
+              "source": null
+            }
+          ]
+        }
+      }
+    },
+    "results": [
+      {
+        "node_bindings": {
+          "n0": [
+            {
+              "id": "NODE_1"
+            }
+          ],
+          "n1": [
+            {
+              "id": "NODE_2",
+              "coalescence_method": "property_enrichment",
+              "p_values": [
+                6.846079020423244e-10
+              ],
+              "properties": [
+                "application"
+              ]
+            }
+          ]
+        },
+        "edge_bindings": {
+          "e01": [
+            {
+              "id": "EDGE_1"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "logs": null,
+  "status": null
+}

--- a/tests/resources/premerged_dupe_edge.json
+++ b/tests/resources/premerged_dupe_edge.json
@@ -1,0 +1,120 @@
+{
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "id": "NODE_1",
+          "category": "biolink:Disease",
+          "is_set": false
+        },
+        "n1": {
+          "id": "NODE_2",
+          "category": "biolink:ChemicalSubstance",
+          "is_set": false,
+          "set": true
+        }
+      },
+      "edges": {
+        "e01": {
+          "subject": "n0",
+          "object": "n1",
+          "predicate": "biolink:correlated_with",
+          "relation": null
+        }
+      }
+    },
+    "knowledge_graph": {
+      "nodes": {
+        "NODE_1": {
+          "category": [
+            "biolink:D",
+            "biolink:I",
+            "biolink:S",
+            "biolink:E",
+            "biolink:A",
+            "biolink:S",
+            "biolink:E"
+          ]
+        },
+        "NODE_2": {
+          "category": [
+            "biolink:ChemicalSubstance"
+          ],
+          "name": "AvgDailyOzoneExposure,AvgDailyOzoneExposure_StudyAvg,AvgDailyOzoneExposure_StudyMax,MaxDailyOzoneExposure,MaxDailyOzoneExposure_StudyAvg,MaxDailyOzoneExposure_StudyMax,AvgDailyOzoneExposure_qcut,AvgDailyOzoneExposure_StudyAvg_qcut,AvgDailyOzoneExposure_StudyMax_qcut,MaxDailyOzoneExposure_qcut,MaxDailyOzoneExposure_StudyAvg_qcut,MaxDailyOzoneExposure_StudyMax_qcut,MaxDailyOzoneExposure_2,MaxDailyOzoneExposure_2_qcut",
+          "attributes": [
+            {
+              "name": "equivalent_identifiers",
+              "type": "EDAM:data_0006",
+              "value": [
+                "PUBCHEM:24823",
+                "SCTID:40057008",
+                "NODE_2",
+                "ENVO:01000537"
+              ]
+            }
+          ]
+        }
+      },
+      "edges": {
+        "EDGE_1": {
+          "subject": "NODE_1",
+          "object": "NODE_2",
+          "predicate": "biolink:correlated_with",
+          "attributes": [
+            {
+              "name": "provenance",
+              "type": "MetaInformation",
+              "value": "https://icees.renci.org:16339/knowledge_graph_one_hop?reasoner=true"
+            }
+          ]
+        },
+        "EDGE_2": {
+          "subject": "NODE_1",
+          "object": "NODE_2",
+          "predicate": "biolink:correlated_with",
+          "attributes": [
+            {
+              "name": "provenance",
+              "type": "MetaInformation",
+              "value": "https://icees.renci.org:16339/knowledge_graph_one_hop?reasoner=true"
+            }
+          ]
+        }
+      }
+    },
+    "results": [
+      {
+        "node_bindings": {
+          "n0": [
+            {
+              "id": "NODE_1"
+            }
+          ],
+          "n1": [
+            {
+              "id": "NODE_2",
+              "coalescence_method": "property_enrichment",
+              "p_values": [
+                6.846079020423244e-10
+              ],
+              "properties": [
+                "application"
+              ]
+            }
+          ]
+        },
+        "edge_bindings": {
+          "e01": [
+            {
+              "id": "EDGE_1"
+            },
+            {
+              "id": "EDGE_2"
+            }
+          ]
+        },
+        "score": 0.0
+      }
+    ]
+  }
+}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -12,6 +12,9 @@ from redis_mocks import mock_get_equivalent_curies
 premerged_response = Path(__file__).parent / 'resources' / 'premerged_response.json'
 postmerged_response = Path(__file__).parent / 'resources' / 'postmerged_response.json'
 
+premerged_dupe_edge = Path(__file__).parent / 'resources' / 'premerged_dupe_edge.json'
+postmerged_dupe_edge = Path(__file__).parent / 'resources' / 'postmerged_dupe_edge.json'
+
 
 class TestServer:
 
@@ -26,6 +29,9 @@ class TestServer:
 
     @patch('node_normalizer.normalizer.get_equivalent_curies', Mock(side_effect=mock_get_equivalent_curies))
     def test_kg_normalize(self):
+        """
+        TODO turn this into a parametrized test for various cases
+        """
         with open(premerged_response, 'r') as pre:
             premerged_data = json.load(pre)
 
@@ -35,5 +41,22 @@ class TestServer:
         response = self.test_client.post('/response', json=premerged_data)
         postmerged_from_api = json.loads(response.text)
         
+        # dictionary equality might be brittle
+        assert postmerged_from_api == postmerged_from_file
+
+    @patch('node_normalizer.normalizer.get_equivalent_curies', Mock(side_effect=mock_get_equivalent_curies))
+    def test_dupe_edge(self):
+        """
+        TODO turn this into a parametrized test for various cases
+        """
+        with open(premerged_dupe_edge, 'r') as pre:
+            premerged_data = json.load(pre)
+
+        with open(postmerged_dupe_edge, 'r') as post:
+            postmerged_from_file = json.load(post)
+
+        response = self.test_client.post('/response', json=premerged_data)
+        postmerged_from_api = json.loads(response.text)
+
         # dictionary equality might be brittle
         assert postmerged_from_api == postmerged_from_file

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -4,11 +4,13 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 import pytest
 
-from reasoner_pydantic import KnowledgeGraph
+from reasoner_pydantic import Attribute, CURIE
 
+
+from reasoner_pydantic import KnowledgeGraph
 # Need to add to sources root to avoid linter warnings
 from redis_mocks import mock_get_equivalent_curies
-from node_normalizer.normalizer import normalize_kgraph
+from node_normalizer.normalizer import normalize_kgraph, _hash_attributes, _merge_node_attributes
 
 
 premerged_graph = Path(__file__).parent / 'resources' / 'premerged_kgraph.json'
@@ -31,3 +33,123 @@ class TestNormalizer:
 
         # dictionary equality might be brittle
         assert postmerged_from_api.dict() == postmerged_from_file
+
+    def test_hashable_attribute(self):
+        # value is a scalar
+        hashable_attribute = Attribute(
+            type=CURIE.parse_obj("foo:bar"),
+            value=3,
+            name='test',
+            source='test_source'
+        )
+        assert _hash_attributes([hashable_attribute]) is not False
+
+        # value is None
+        hashable_attribute = Attribute(
+            type=CURIE.parse_obj("foo:bar"),
+            value=None,
+            name='test',
+            source='test_source'
+        )
+        assert _hash_attributes([hashable_attribute]) is not False
+
+        # value is a list
+        hashable_attribute = Attribute(
+            type=CURIE.parse_obj("foo:bar"),
+            value=[1,2,3],
+            name='test',
+            source='test_source'
+        )
+
+        assert _hash_attributes([hashable_attribute]) is not False
+
+        # value is a dict of scalars/lists
+        hashable_attribute = Attribute(
+            type=CURIE.parse_obj("foo:bar"),
+            value={1:2, 3:[4,5]},
+            name='test',
+            source='test_source'
+        )
+
+        assert _hash_attributes([hashable_attribute]) is not False
+
+        # None check
+        assert _hash_attributes(None) is not False
+        assert _hash_attributes(None) == _hash_attributes(None)
+
+        # Sanity checks
+        assert _hash_attributes([Attribute(type=CURIE.parse_obj("foo:bar"), value=1)]) == \
+               _hash_attributes([Attribute(type=CURIE.parse_obj("foo:bar"), value=1)])
+
+        assert _hash_attributes([Attribute(type=CURIE.parse_obj("foo:bar"), value=1)]) != \
+               _hash_attributes([Attribute(type=CURIE.parse_obj("foo:bar"), value=2)])
+
+    def test_unhashable_attribute(self):
+        # value is a nested dict
+        hashable_attribute = Attribute(
+            type=CURIE.parse_obj("foo:bar"),
+            value={1:{2:3}},
+            name='test',
+            source='test_source'
+        )
+        assert _hash_attributes([hashable_attribute]) is False
+
+    def test_merge_node_attributes(self):
+        node_a = {
+            'id': 'primary:id',
+            'attributes': [
+                {
+                    'type': 'bar:baz',
+                    'value': 1
+                }
+            ]
+        }
+
+        node_b = {
+            'id': 'secondary:id',
+            'attributes': [
+                {
+                    'type': 'bar:baz',
+                    'value': 2
+                }
+            ]
+        }
+        new_node = _merge_node_attributes(node_a, node_b, 0)
+        assert new_node == {
+            'id': 'primary:id',
+            'attributes': [
+                {
+                    'type.1': 'bar:baz',
+                    'value.1': 1
+                },
+                {
+                    'type.2': 'bar:baz',
+                    'value.2': 2
+                }
+            ]
+        }
+
+        node_a = {
+            'id': 'primary:id',
+            'attributes': [
+                {
+                    'type.1': 'bar:baz',
+                    'value.1': 1
+                }
+            ]
+        }
+
+        new_node = _merge_node_attributes(node_a, node_b, 1)
+        assert new_node == {
+            'id': 'primary:id',
+            'attributes': [
+                {
+                    'type.1': 'bar:baz',
+                    'value.1': 1
+                },
+                {
+                    'type.3': 'bar:baz',
+                    'value.3': 2
+                }
+            ]
+        }


### PR DESCRIPTION
An attempt at better managing how we merge nodes and edges with different attributes or extra fields:
- In the results graph, only merge duplicates if all extra fields are identical (assuming there's not deep nesting of extra fields that cannot be hashed)
- In the knowledge graph, nodes are merged based only on id and attributes are merged with updated keys attribute[value.1, value.2, ...]
- In the knowledge graph, only merge edges if all attributes are identical (some attempt at hashing Any, but not guaranteed to work on nested objects)
- No updates to the question graph logic

Ids will still be updated even if an kgraph edge or result is not entirely duplicated

This is fairly complicated so I'll probably need to add more testing before feeling confident that everything is working as specified.