### PR TITLE
fix attributes

### DIFF
--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -58,6 +58,12 @@ async def normalize_results(
                     merged_binding = n_bind.dict()
                     merged_binding['id'] = node_id_map[n_bind.id.__root__]
 
+                    node_binding_information = [
+                            "atts" if k == 'attributes'
+                            else (k, tuple(v)) if isinstance(v, list)
+                            else (k, v)
+                            for k, v in merged_binding.items()
+                        ]
                     # if there are attributes in the node binding
                     if 'attributes' in merged_binding:
                         # storage for the pydantic Attributes
@@ -72,14 +78,9 @@ async def normalize_results(
                             attribs.append(new_attrib)
 
                         # call to get the hash
-                        node_binding_hash = _hash_attributes(attribs)
-                    else:
-                        node_binding_hash = frozenset([
-                            (k, tuple(v))
-                            if isinstance(v, list)
-                            else (k, v)
-                            for k, v in merged_binding.items()
-                        ])
+                        atty_hash = _hash_attributes(attribs)
+                        node_binding_information.append(atty_hash)
+                    node_binding_hash = frozenset(node_binding_information)
 
                     if node_binding_hash in node_binding_seen:
                         continue
@@ -111,12 +112,9 @@ async def normalize_results(
                 merged_result['edge_bindings'][edge_code] = merged_edge_bindings
 
             try:
-                hashed_result = frozenset([
-                    (k, tuple(v))
-                    if isinstance(v, list)
-                    else (k, v)
-                    for k, v in merged_result.items()
-                ])
+                #This used to have some list comprehension based on types.  But in TRAPI 1.1 the list/dicts get pretty deep.
+                #This is simpler, and the sort_keys argument makes sure we get a constant result.
+                hashed_result = json.dumps(merged_result, sort_keys=True)
 
             except Exception as e:  # TODO determine exception(s) to catch
                 logger.error(f'Exception: {e}')
@@ -148,26 +146,24 @@ async def normalize_qgraph(app: FastAPI, qgraph: QueryGraph) -> QueryGraph:
         try:
             merged_nodes[node_code] = node.dict()
 
+            # as of TRAPI 1.1, node.id must be none or a list.
             # node.id can be none, a string, or a list
             if not node.ids:
                 # do nothing
                 continue
-            elif isinstance(node.ids, list):
-                equivalent_curies = await get_normalized_nodes(app, node.ids)
+            else:
+                if not isinstance(node.ids, list):
+                    raise Exception("node.ids must be a list")
                 primary_ids = set()
                 for nid in node.ids:
-                    if equivalent_curies[nid.__root__]:
-                        primary_ids.add(equivalent_curies[nid.__root__]['id']['identifier'])
+                    nr = nid.__root__
+                    equivalent_curies = await get_equivalent_curies(app,nid)
+                    if equivalent_curies[nr]:
+                        primary_ids.add(equivalent_curies[nr]['id']['identifier'])
                     else:
-                        primary_ids.add(nid)
-                merged_nodes[node_code]['id'] = list(primary_ids)
+                        primary_ids.add(nr)
+                merged_nodes[node_code]['ids'] = list(primary_ids)
                 node_code_map[node_code] = list(primary_ids)
-            else:
-                equivalent_curies = await get_equivalent_curies(app, node.ids)
-                if equivalent_curies[node.ids.__root__]:
-                    primary_id = equivalent_curies[node.ids.__root__]['id']['identifier']
-                    merged_nodes[node_code]['id'] = primary_id
-                    node_code_map[node_code] = primary_id
         except Exception as e:
             logger.error(f'Exception: {e}')
 

--- a/tests/resources/input_set.json
+++ b/tests/resources/input_set.json
@@ -1,0 +1,67 @@
+{
+  "message":
+  {
+    "query_graph":
+    {
+      "nodes":
+      {
+        "disease": {
+          "ids": ["MONDO:0005002"]
+        },
+        "drug": {
+          "categories": ["biolink:ChemicalSubstance"],
+          "set": "true"
+        }
+      },
+      "edges":
+      {
+        "treats":
+        {
+          "subject": "disease",
+          "object": "drug",
+          "predicates": ["biolink:treats"]
+        }
+      }
+    },
+    "knowledge_graph":
+    {
+      "nodes":
+      {
+        "MONDO:0005002": {"categories": ["biolink:Disease"]},
+        "PUBCHEM.COMPOUND:2468": {"categories":  ["biolink:ChemicalSubstance"]},
+        "PUBCHEM.COMPOUND:3488": {"categories":  ["biolink:ChemicalSubstance"]}
+      },
+      "edges":
+      {
+        "edge1": {"subject": "MONDO:0005002", "object":  "PUBCHEM.COMPOUND:2468", "predicate": "biolink:treats"},
+        "edge2": {"subject": "MONDO:0005002", "object":  "PUBCHEM.COMPOUND:3488", "predicate": "biolink:treats"}
+      }
+    },
+    "results":
+    [
+      {
+        "node_bindings": {
+          "disease": [{"id":"MONDO:0005002"}],
+          "drug": [{"id":"PUBCHEM.COMPOUND:2468",
+            "attributes": [
+              {"original_attribute_name": "coalescence_method", "attribute_type_id": "biolink:has_attribute", "value": "property_enrichment", "value_type_id": "EDAM:operation_0004"},
+              {"original_attribute_name": "p_value", "attribute_type_id": "biolink:has_numeric_value", "value": [1.025238759711833e-07, 8.462894040203764e-07, 6.741080520186477e-06], "value_type_id": "EDAM:data_1669"},
+              {"original_attribute_name": "properties", "attribute_type_id": "biolink:has_attribute", "value": ["Drugs Used in Diabetes", "hypoglycemic_agent", "Alimentary Tract and Metabolism"], "value_type_id": "EDAM:data_0006"}
+            ]
+          },
+            {"id":"PUBCHEM.COMPOUND:3488",
+             "attributes": [
+              {"original_attribute_name": "coalescence_method", "attribute_type_id": "biolink:has_attribute", "value": "property_enrichment", "value_type_id": "EDAM:operation_0004"},
+              {"original_attribute_name": "p_value", "attribute_type_id": "biolink:has_numeric_value", "value": [1.025238759711833e-07, 8.462894040203764e-07, 6.741080520186477e-06], "value_type_id": "EDAM:data_1669"},
+              {"original_attribute_name": "properties", "attribute_type_id": "biolink:has_attribute", "value": ["Drugs Used in Diabetes", "hypoglycemic_agent", "Alimentary Tract and Metabolism"], "value_type_id": "EDAM:data_0006"}
+            ]
+          }
+        ]},
+        "edge_bindings":
+        {
+          "treats": [{"id":"edge1"},{ "id":"edge2"}]
+        }
+      }
+    ]
+  }
+}

--- a/tests/resources/mock-redis/PUBCHEM.COMPOUND_2468.json
+++ b/tests/resources/mock-redis/PUBCHEM.COMPOUND_2468.json
@@ -1,0 +1,54 @@
+{
+  "PUBCHEM.COMPOUND:2468": {
+    "id": {
+      "identifier": "PUBCHEM.COMPOUND:2468",
+      "label": "Buformin"
+    },
+    "equivalent_identifiers": [
+      {
+        "identifier": "PUBCHEM.COMPOUND:2468",
+        "label": "Buformin"
+      },
+      {
+        "identifier": "CHEMBL.COMPOUND:CHEMBL39736",
+        "label": "BUFORMIN"
+      },
+      {
+        "identifier": "UNII:W2115E9C7B",
+        "label": "BUFORMIN"
+      },
+      {
+        "identifier": "CHEBI:3209",
+        "label": "Buformin"
+      },
+      {
+        "identifier": "DRUGBANK:DB04830"
+      },
+      {
+        "identifier": "MESH:D002026",
+        "label": "Buformin"
+      },
+      {
+        "identifier": "CAS:692-13-7"
+      },
+      {
+        "identifier": "DrugCentral:423",
+        "label": "buformin"
+      },
+      {
+        "identifier": "KEGG.COMPOUND:C07674",
+        "label": "Buformin"
+      },
+      {
+        "identifier": "INCHIKEY:XSEUMFJMFFMCIU-UHFFFAOYSA-N"
+      }
+    ],
+    "type": [
+      "biolink:ChemicalSubstance",
+      "biolink:MolecularEntity",
+      "biolink:BiologicalEntity",
+      "biolink:NamedThing",
+      "biolink:Entity"
+    ]
+  }
+}

--- a/tests/resources/mock-redis/PUBCHEM.COMPOUND_3488.json
+++ b/tests/resources/mock-redis/PUBCHEM.COMPOUND_3488.json
@@ -1,0 +1,62 @@
+{
+  "PUBCHEM.COMPOUND:3488": {
+    "id": {
+      "identifier": "PUBCHEM.COMPOUND:3488",
+      "label": "Glyburide"
+    },
+    "equivalent_identifiers": [
+      {
+        "identifier": "PUBCHEM.COMPOUND:3488",
+        "label": "Glyburide"
+      },
+      {
+        "identifier": "CHEMBL.COMPOUND:CHEMBL472",
+        "label": "GLYBURIDE"
+      },
+      {
+        "identifier": "UNII:SX6K58TVWC",
+        "label": "GLYBURIDE"
+      },
+      {
+        "identifier": "CHEBI:5441",
+        "label": "glyburide"
+      },
+      {
+        "identifier": "DRUGBANK:DB01016"
+      },
+      {
+        "identifier": "MESH:D005905",
+        "label": "Glyburide"
+      },
+      {
+        "identifier": "CAS:10238-21-8"
+      },
+      {
+        "identifier": "DrugCentral:1314",
+        "label": "glibenclamide"
+      },
+      {
+        "identifier": "GTOPDB:2414",
+        "label": "glibenclamide"
+      },
+      {
+        "identifier": "HMDB:HMDB0015151",
+        "label": "Glyburide"
+      },
+      {
+        "identifier": "KEGG.COMPOUND:C07022",
+        "label": "Glyburide"
+      },
+      {
+        "identifier": "INCHIKEY:ZNNLBTZKUZBEKO-UHFFFAOYSA-N"
+      }
+    ],
+    "type": [
+      "biolink:ChemicalSubstance",
+      "biolink:MolecularEntity",
+      "biolink:BiologicalEntity",
+      "biolink:NamedThing",
+      "biolink:Entity"
+    ]
+  }
+}

--- a/tests/resources/postmerged_response.json
+++ b/tests/resources/postmerged_response.json
@@ -3,7 +3,7 @@
     "query_graph": {
       "nodes": {
         "n1": {
-          "ids": ["HGNC:11603"],
+          "ids": ["NCBIGene:9496"],
           "categories": [
             "biolink:Gene"
           ],
@@ -27,7 +27,7 @@
           "constraints": null
         },
         "n4": {
-          "ids": ["DOID:3083"],
+          "ids": ["MONDO:0005002"],
           "categories": [
             "biolink:Disease"
           ],


### PR DESCRIPTION
Found a bug in which results from answer coalesce were not properly normed.  In particular, if there were multiple nodes in a node binding result:
```
"node_bindings" { "n1": [{"id":"foo", "attributes":[...]}, {"id":"bar","attributes":[...]}]}
```
And if the node bindings had attributes, as above, then only one of the bindings would be kept, i.e. the output would have 
```
"n1":[{"id":"foo", "attributes":...}]
```

This adds a test and fixes that.  In addition, it cleans up various parts of the merge that didn't seem to be working very well, especially in the qgraph.