### PR TITLE
Conflation

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,9 @@
 {
-    "compendium_directory": "",
-    "redis_host": "",
-    "redis_port": 0,
+    "compendium_directory": "comps",
+    "redis_host": "127.0.0.1",
+    "redis_port": 6379,
     "redis_password": "",
-    "data_files": "anatomy.txt,biological_process.txt,cell.txt,cellular_component.txt,chemconc.txt,disease.txt,gene_compendium.txt,gene_family_compendium.txt,molecular_activity.txt,pathways.txt,phenotypes.txt,taxon_compendium.txt",
-    "test_mode": 1,
+    "data_files": "Disease.txt",
+    "test_mode": 0,
     "debug_messages": 0
 }

--- a/config.json
+++ b/config.json
@@ -1,9 +1,17 @@
 {
     "compendium_directory": "comps",
+    "conflation_directory": "confs",
     "redis_host": "127.0.0.1",
     "redis_port": 6379,
     "redis_password": "",
-    "data_files": "Disease.txt",
+    "data_files": ["Gene.txt", "Protein.txt"],
     "test_mode": 0,
-    "debug_messages": 0
+    "debug_messages": 0,
+    "conflations": [
+        {
+            "types": ["biolink:Gene", "biolink:Protein"],
+            "file": "GeneProtein.txt",
+            "redis_db": 4
+        }
+    ]
 }

--- a/node_normalizer/loader.py
+++ b/node_normalizer/loader.py
@@ -9,6 +9,7 @@ from itertools import combinations
 import jsonschema
 import os
 from node_normalizer.redis_adapter import RedisConnectionFactory, RedisConnection
+from bmt import Toolkit
 
 
 class NodeLoader:
@@ -33,6 +34,19 @@ class NodeLoader:
         # Initialize storage instance vars for the semantic types and source prefixes
         self.semantic_types: set = set()
         self.source_prefixes: Dict = {}
+
+        self.toolkit = Toolkit('https://raw.githubusercontent.com/biolink/biolink-model/2.1.0/biolink-model.yaml')
+        self.ancestor_map = {}
+
+    def get_ancestors(self, input_type):
+        if input_type in self.ancestor_map:
+            return self.ancestor_map[input_type]
+        a = self.toolkit.get_ancestors(input_type)
+        ancs = [self.toolkit.get_element(ai)['class_uri'] for ai in a]
+        if input_type not in ancs:
+            ancs = [input_type] + ancs
+        self.ancestor_map[input_type] = ancs
+        return ancs
 
     @staticmethod
     def get_config() -> Dict[str, Any]:
@@ -171,6 +185,22 @@ class NodeLoader:
         Given a compendia directory, load every file there into a running
         redis instance so that it can be read by R3
         """
+        #The new style compendia files look like:
+        #{"type": "biolink:Disease", "identifiers": [{"i": "UMLS:C4331330", "l": "Stage III Oropharyngeal (p16-Negative) Carcinoma AJCC v8"}, {"i": "NCIT:C132998", "l": "Stage III Oropharyngeal (p16-Negative) Carcinoma AJCC v8"}]}
+        #{"type": "biolink:Disease", "identifiers": [{"i": "UMLS:C1274244", "l": "Dermatosis in a child"}, {"i": "SNOMEDCT:402803008"}]}
+        # Type is now a single biolink type so that we can save space rather than the gigantic array
+        # identifiers replaces equivalent identifiers, and the keys are "i" and "l" rather than 'identifer" and "label".
+        # the identifiers are ordered, such that the first identifier is the best identifier.
+        # We are going to put these different parts into a few different redis tables, and reassemble and nicify on
+        # output.  This will be a touch slower, but it will save a lot of space, and make conflation easier as well.
+
+        # We will have the following redis databases:
+        # 0: contains identifier.upper() -> canonical_id
+        # 1: canonical_id -> equivalent_identifiers
+        # 2: canonical_id -> biolink type
+        # 3: types -> prefix counts
+        # 4-X: conflation databases consisting of canonical_id -> (list of conflated canonical_ids)
+        #      Each of these databases corresponds to a particular conflation e.g. gene/protein or chemical/drug
 
         # init the return value
         ret_val = True
@@ -198,7 +228,7 @@ class NodeLoader:
                         continue
 
                 # get the connection and pipeline to the database
-                types_prefixes_redis: RedisConnection = await self.get_redis(2)
+                types_prefixes_redis: RedisConnection = await self.get_redis(3)
                 types_prefixes_pipeline = types_prefixes_redis.pipeline()
 
                 # create a command to get the current semantic types
@@ -272,14 +302,17 @@ class NodeLoader:
 
         return file_list
 
+    #TODO: this strikes me as backwards.  Caller has to know and look up by index.  So the info about what index
+    # does what is scattered.  Instead this should look up by what kind of redis you want and map to dbid for you.
     async def get_redis(self, dbid):
         """
         Return a redis instance
         """
         db_id_mapping = {
             0: RedisConnectionFactory.ID_TO_ID_DB_CONNECTION_NAME,
-            1: RedisConnectionFactory.ID_TO_NODE_DATA_DB_CONNECTION_NAME,
-            2: RedisConnectionFactory.CURIE_PREFIX_TO_BL_TYPE_DB_CONNECTION_NAME
+            1: RedisConnectionFactory.ID_TO_IDENTIFIERS_CONNECTION_NAME,
+            2: RedisConnectionFactory.ID_TO_TYPE_CONNECTION_NAME,
+            3: RedisConnectionFactory.CURIE_PREFIX_TO_BL_TYPE_DB_CONNECTION_NAME
         }
         redis_config_path = Path(__file__).parent.parent / 'redis_config.yaml'
         connection_factory: RedisConnectionFactory = await RedisConnectionFactory.create_connection_pool(redis_config_path)
@@ -297,10 +330,12 @@ class NodeLoader:
         line_counter: int = 0
         try:
             term2id_redis: RedisConnection = await self.get_redis(0)
-            id2instance_redis: RedisConnection = await self.get_redis(1)
+            id2eqids_redis: RedisConnection = await self.get_redis(1)
+            id2type_redis: RedisConnection = await self.get_redis(2)
 
             term2id_pipeline = term2id_redis.pipeline()
-            id2instance_pipeline = id2instance_redis.pipeline()
+            id2eqids_pipeline = id2eqids_redis.pipeline()
+            id2type_pipeline = id2type_redis.pipeline()
 
             with open(compendium_filename, 'r', encoding="utf-8") as compendium:
                 self.print_debug_msg(f'Processing {compendium_filename}...', True)
@@ -313,8 +348,13 @@ class NodeLoader:
                     instance: dict = json.loads(line)
 
                     # save the identifier
-                    identifier: str = instance['id']['identifier']
+                    # "The" identifier is the first one in the presorted identifiers list
+                    identifier: str = instance['identifiers'][0]['i']
 
+                    # We want to accumulate statistics for each implied type as well, though we are only keeping the
+                    # leaf type in the file (and redis).  so now is the time to expand.  We'll regenerate the same
+                    # list on output.
+                    semantic_types = self.get_ancestors(instance['type'])
                     # for each semantic type in the list
                     for semantic_type in instance['type']:
                         # save the semantic type in a set to avoid duplicates
@@ -326,9 +366,9 @@ class NodeLoader:
 
                         # go through each equivalent identifier in the data row
                         # each will be assigned the semantic type information
-                        for equivalent_id in instance['equivalent_identifiers']:
+                        for equivalent_id in instance['identifiers']:
                             # split the identifier to just get the data source out of the curie
-                            source_prefix: str = equivalent_id['identifier'].split(':')[0]
+                            source_prefix: str = equivalent_id['i'].split(':')[0]
 
                             # save the source prefix if no already there
                             if self.source_prefixes[semantic_type].get(source_prefix) is None:
@@ -339,23 +379,27 @@ class NodeLoader:
 
                             # equivalent_id might be an array, where the first element is
                             # the identifier, or it might just be a string. not worrying about that case yet.
-                            equivalent_id = equivalent_id['identifier']
+                            equivalent_id = equivalent_id['i']
                             term2id_pipeline.set(equivalent_id, identifier)
                             term2id_pipeline.set(equivalent_id.upper(), identifier)
 
-                        id2instance_pipeline.set(identifier, line)
+                        id2eqids_pipeline.set(identifier, json.dumps(instance['identifiers']))
+                        id2type_pipeline.set(identifier, instance['type'])
 
                     if self._test_mode != 1 and line_counter % block_size == 0:
                         await RedisConnection.execute_pipeline(term2id_pipeline)
-                        await RedisConnection.execute_pipeline(id2instance_pipeline)
-                        # Pipeline executed create a new one error 
+                        await RedisConnection.execute_pipeline(id2eqids_pipeline)
+                        await RedisConnection.execute_pipeline(id2type_pipeline)
+                        # Pipeline executed create a new one error
                         term2id_pipeline = term2id_redis.pipeline()
-                        id2instance_pipeline = id2instance_redis.pipeline()
+                        id2eqids_pipeline = id2eqids_redis.pipeline()
+                        id2type_pipeline = id2type_redis.pipeline()
                         self.print_debug_msg(f'{line_counter} {compendium_filename} lines processed.', True)
 
                 if self._test_mode != 1:
                     await RedisConnection.execute_pipeline(term2id_pipeline)
-                    await RedisConnection.execute_pipeline(id2instance_pipeline)
+                    await RedisConnection.execute_pipeline(id2eqids_pipeline)
+                    await RedisConnection.execute_pipeline(id2type_pipeline)
                     self.print_debug_msg(f'{line_counter} {compendium_filename} total lines processed.', True)
 
                 print(f'Done loading {compendium_filename}...')

--- a/node_normalizer/model/__init__.py
+++ b/node_normalizer/model/__init__.py
@@ -3,4 +3,4 @@ API Models not described in reasoner-pydantic
 """
 
 from .input import CurieList, SemanticTypesInput
-from .response import CuriePivot, SemanticTypes
+from .response import CuriePivot, SemanticTypes, ConflationList

--- a/node_normalizer/model/input.py
+++ b/node_normalizer/model/input.py
@@ -15,6 +15,11 @@ class CurieList(BaseModel):
         title='list of nodes formatted as curies'
     )
 
+    conflate:bool = Field (
+        True,
+        title="Whether to apply conflation"
+    )
+
     class Config:
         schema_extra = {
             "example": {

--- a/node_normalizer/model/response.py
+++ b/node_normalizer/model/response.py
@@ -26,3 +26,6 @@ class SemanticTypes(BaseModel):
 
 class CuriePivot(BaseModel):
     curie_prefix: Dict[str, str]
+
+class ConflationList(BaseModel):
+    conflations: List

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -383,6 +383,14 @@ async def get_equivalent_curies(
 
     return {curie: json.loads(value) if value is not None else None}
 
+async def get_eqids_and_types(
+        app: FastAPI,
+        canonical_nonan: List ) -> (List,List):
+    eqids = await app.state.redis_connection1.mget(*canonical_nonan, encoding='utf-8')
+    eqids = [json.loads(value) if value is not None else None for value in eqids]
+    types = await app.state.redis_connection2.mget(*canonical_nonan, encoding='utf-8')
+    types = [get_ancestors(app, t) for t in types]
+    return eqids, types
 
 async def get_normalized_nodes(
         app: FastAPI,
@@ -398,31 +406,58 @@ async def get_normalized_nodes(
     ]
     normal_nodes = {}
 
-    upper_curies = [c.uppercase() for c in curies]
+    #TODO: Add an option that lets one choose which conflations to do, and get the details of those conflations
+    # from the configs.
+
+    conflation_types = set(["biolink:Gene","biolink:Protein"])
+    conflation_redis = 4
+
+    upper_curies = [c.upper() for c in curies]
     try:
         canonical_ids = await app.state.redis_connection0.mget(*upper_curies, encoding='utf-8')
         canonical_nonan = [canonical_id for canonical_id in canonical_ids if canonical_id is not None]
         #Get the equivalent_ids and types
         if canonical_nonan:
-            eqids = await app.state.redis_connection1.mget(*canonical_nonan, encoding='utf-8')
-            eqids = [json.loads(value) if value is not None else None for value in eqids]
-            dereference_ids = dict(zip(canonical_nonan, eqids))
-            types =  await app.state.redis_connection2.mget(*canonical_nonan, encoding='utf-8')
-            types = [json.loads(value) if value is not None else None for value in types]
-            dereference_types = dict(zip(canonical_nonan, types))
+            eqids, types = await get_eqids_and_types(app,canonical_nonan)
+            #TODO: filter to just types that have Gene or Protein?  I'm not sure it's worth it when we have pipelining
+            other_ids = await app.state.redis_connection4.mget(*canonical_nonan, encoding='utf8')
+            #if there are other ids, then we want to rebuild eqids and types.  That's because even though we have them,
+            # they're not necessarily first.  For instance if what came in and got canonicalized was a protein id
+            # and we want gene first, then we're relying on the order of the other_ids to put it back in the right place.
+            other_ids = [ json.loads(oids) if other_ids is not None else [] for oids in other_ids ]
+            dereference_others = dict(zip(canonical_nonan,other_ids))
+            all_other_ids = sum(other_ids,[])
+            eqids2, types2 = await get_eqids_and_types(app,all_other_ids)
+            final_eqids = []
+            final_types = []
+            deref_others_eqs = dict(zip(all_other_ids,eqids2))
+            deref_others_typ = dict(zip(all_other_ids,types2))
+            for canonical_id,e,t in zip(canonical_nonan,eqids,types):
+                #here's where we replace the eqids, types
+                if len(dereference_others[canonical_id]) > 0:
+                    e = []
+                    t = []
+                for other in dereference_others[canonical_id]:
+                    e += deref_others_eqs[other]
+                    t += deref_others_typ[other]
+                final_eqids.append(e)
+                final_types.append(list(set(t)))
+            dereference_ids   = dict(zip(canonical_nonan, final_eqids))
+            dereference_types = dict(zip(canonical_nonan, final_types))
         else:
-            dereference_ids = dict()
+            dereference_ids   = dict()
             dereference_types = dict()
         normal_nodes = {
-            input_curie: create_node(app, canonical_id,dereference_ids,dereference_types)
+            input_curie: await create_node(canonical_id,dereference_ids,dereference_types)
             for input_curie, canonical_id in zip(curies, canonical_ids)
         }
+
     except Exception as e:
         logger.error(f'Exception: {e}')
 
     return normal_nodes
 
-async def create_node(app, canonical_id, equivalent_ids, types):
+async def create_node(canonical_id, equivalent_ids, types):
     """Construct the output format given the compressed redis data"""
     # It's possible that we didn't find a canonical_id
     if canonical_id is None:
@@ -430,18 +465,17 @@ async def create_node(app, canonical_id, equivalent_ids, types):
     #OK, now we should have id's in the format [ {"i": "MONDO:12312", "l": "Scrofula"}, {},...]
     eids = equivalent_ids[canonical_id]
     #First, we need to create the "id" node.  The identifier is our input canonical id, but we have to get a label
-    labels = list(filter(lambda x: len(x) > 0, [l['l'] for l in eids[canonical_id] if 'l' in l]))
+    labels = list(filter(lambda x: len(x) > 0, [l['l'] for l in eids if 'l' in l]))
+    #Note that the id will be from the equivalent ids, not the canonical_id.  This is to handle conflation
     if len(labels) > 0:
-        node = { "id" : {"identifier": canonical_id, "label": labels[0]}}
+        node = { "id" : {"identifier": eids[0]['i'], "label": labels[0]}}
     else:
         #Sometimes, nothing has a label :(
-        node = { "id" : {"identifier": canonical_id}}
+        node = { "id" : {"identifier": eids[0]['i']}}
     #now need to reformat the identifier keys.  It could be cleaner but we have to worry about if there is a label
     node['equivalent_identifiers'] = [ {"identifier":eqid["i"], "label":eqid["l"]} if "l" in eqid
                                        else {"identifier":eqid["i"]} for eqid in eids]
-    #and construct the type.  We are only keeping the leaf type, so we need to look up the ancestors and create the
-    # list
-    node['type'] = get_ancestors(app, types[canonical_id])
+    node['type'] = types[canonical_id]
     return node
 
 async def get_curie_prefixes(

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -499,7 +499,7 @@ async def get_curie_prefixes(
         if semantic_types:
             for item in semantic_types:
                 # get the curies for this type
-                curies = await app.state.redis_connection2.get(item, encoding='utf-8')
+                curies = await app.state.redis_connection3.get(item, encoding='utf-8')
 
                 # did we get any data
                 if not curies:
@@ -510,11 +510,11 @@ async def get_curie_prefixes(
                 # set the return data
                 ret_val[item] = {'curie_prefix': curies}
         else:
-            types = await app.state.redis_connection2.lrange('semantic_types', 0, -1, encoding='utf-8')
+            types = await app.state.redis_connection3.lrange('semantic_types', 0, -1, encoding='utf-8')
 
             for item in types:
                 # get the curies for this type
-                curies = await app.state.redis_connection2.get(item, encoding='utf-8')
+                curies = await app.state.redis_connection3.get(item, encoding='utf-8')
 
                 # did we get any data
                 if not curies:

--- a/node_normalizer/redis_adapter.py
+++ b/node_normalizer/redis_adapter.py
@@ -36,6 +36,7 @@ class ConnectionConfig:
     id_to_eqids_db: RedisInstance
     id_to_type_db: RedisInstance
     curie_to_bl_type_db: RedisInstance
+    gene_protein_db: RedisInstance
 
     def __post_init__(self):
         # Converts inner data dicts to dataclasses
@@ -47,6 +48,8 @@ class ConnectionConfig:
             self.id_to_type_db = RedisInstance(**self.id_to_type_db)
         if isinstance(self.eq_id_to_id_db, dict):
             self.eq_id_to_id_db = RedisInstance(**self.eq_id_to_id_db)
+        if isinstance(self.gene_protein_db, dict):
+            self.gene_protein_db = RedisInstance(**self.gene_protein_db)
 
 
 class RedisConnection:
@@ -171,6 +174,7 @@ class RedisConnectionFactory:
     ID_TO_IDENTIFIERS_CONNECTION_NAME = 'id_to_eqids'
     ID_TO_TYPE_CONNECTION_NAME = 'id_to_type'
     CURIE_PREFIX_TO_BL_TYPE_DB_CONNECTION_NAME = 'curie_to_bl'
+    GENE_PROTEIN_CONFLATION_DB_CONNECTION_NAME = 'gene_protein'
 
     def __init__(self):
         pass
@@ -191,7 +195,8 @@ class RedisConnectionFactory:
                 RedisConnectionFactory.ID_TO_ID_DB_CONNECTION_NAME: await RedisConnection.create(config.eq_id_to_id_db),
                 RedisConnectionFactory.ID_TO_IDENTIFIERS_CONNECTION_NAME: await RedisConnection.create(config.id_to_eqids_db),
                 RedisConnectionFactory.ID_TO_TYPE_CONNECTION_NAME: await RedisConnection.create(config.id_to_type_db),
-                RedisConnectionFactory.CURIE_PREFIX_TO_BL_TYPE_DB_CONNECTION_NAME: await RedisConnection.create(config.curie_to_bl_type_db)
+                RedisConnectionFactory.CURIE_PREFIX_TO_BL_TYPE_DB_CONNECTION_NAME: await RedisConnection.create(config.curie_to_bl_type_db),
+                RedisConnectionFactory.GENE_PROTEIN_CONFLATION_DB_CONNECTION_NAME: await RedisConnection.create(config.gene_protein_db)
             }
         return self
 

--- a/node_normalizer/resources/openapi.yml
+++ b/node_normalizer/resources/openapi.yml
@@ -27,6 +27,8 @@ info:
 servers:
   - description: Default server
     url: https://nodenormalization-sri.renci.org/
+  - description: Local
+    url: http://0.0.0.0:8000/
 tags:
   - name: translator
   - name: Interfaces
@@ -153,5 +155,22 @@ paths:
           description: Results
       summary: Return a list of BioLink semantic types for which normalization has
         been attempted.
+      tags:
+      - Interfaces
+  /get_allowed_conflations:
+    get:
+      description: Returns a list of allowed conflation options
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                example:
+                  conflations:
+                    - GeneProtein
+                    - DrugChemical
+                type: object
+          description: Results
+      summary: Return a list of named conflations.
       tags:
       - Interfaces

--- a/node_normalizer/resources/valid_data_format.json
+++ b/node_normalizer/resources/valid_data_format.json
@@ -5,56 +5,24 @@
 	"title": "Root",
 	"type": "object",
 	"required": [
-		"id",
-		"equivalent_identifiers",
+		"identifiers",
 		"type"
 	],
 	"properties": {
-		"id": {
-			"$id": "#root/id",
-			"title": "Id",
-			"type": "object",
-			"required": [
-				"identifier"
-			],
-			"properties": {
-				"identifier": {
-					"$id": "#root/id/identifier",
-					"title": "Identifier",
-					"type": "string",
-					"default": "",
-					"examples": [
-						"UBERON:0012326"
-					],
-					"pattern": "^.*$"
-				},
-				"label": {
-					"$id": "#root/id/label",
-					"title": "Label",
-					"type": "string",
-					"default": "",
-					"examples": [
-						"gubernacular bulb"
-					],
-					"pattern": "^.*$"
-				}
-			}
-		}
-,
 		"equivalent_identifiers": {
-			"$id": "#root/equivalent_identifiers",
+			"$id": "#root/identifiers",
 			"title": "Equivalent_identifiers",
 			"type": "array",
 			"default": [],
-			"items":{
-				"$id": "#root/equivalent_identifiers/items",
+			"items": {
+				"$id": "#root/identifiers/items",
 				"title": "Items",
 				"type": "object",
 				"required": [
-					"identifier"
+					"i"
 				],
 				"properties": {
-					"identifier": {
+					"i": {
 						"$id": "#root/equivalent_identifiers/items/identifier",
 						"title": "Identifier",
 						"type": "string",
@@ -64,7 +32,7 @@
 						],
 						"pattern": "^.*$"
 					},
-					"label": {
+					"l": {
 						"$id": "#root/equivalent_identifiers/items/label",
 						"title": "Label",
 						"type": "string",
@@ -76,23 +44,13 @@
 					}
 				}
 			}
-
 		},
 		"type": {
 			"$id": "#root/type",
 			"title": "Type",
-			"type": "array",
-			"default": [],
-			"items":{
-				"$id": "#root/type/items",
-				"title": "Items",
-				"type": "string",
-				"default": "",
-				"examples": [
-					"anatomical_entity"
-				],
-				"pattern": "^.*$"
-			}
+			"type": "string",
+			"default": "",
+			"pattern": "^.*$"
 		}
 	}
 }

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -97,12 +97,12 @@ async def get_conflations() -> ConflationList:
     summary='Get the equivalent identifiers and semantic types for the curie(s) entered.',
     description='Returns the equivalent identifiers and semantic types for the curie(s)'
 )
-async def get_normalized_node_handler(curie: List[str] = Query([], example=['MESH:D014867', 'NCIT:C34373'])):
+async def get_normalized_node_handler(curie: List[str] = Query([], example=['MESH:D014867', 'NCIT:C34373']), conflate: bool =True):
     """
     Get value(s) for key(s) using redis MGET
     """
     #no_conflate = request.args.get('dontconflate',['GeneProtein'])
-    normalized_nodes = await get_normalized_nodes(app, curie)
+    normalized_nodes = await get_normalized_nodes(app, curie, conflate)
 
     return normalized_nodes
 
@@ -116,7 +116,7 @@ async def get_normalized_node_handler(curies: CurieList):
     """
     Get value(s) for key(s) using redis MGET
     """
-    normalized_nodes = await get_normalized_nodes(app, curies.curies)
+    normalized_nodes = await get_normalized_nodes(app, curies.curies, True)
 
     return normalized_nodes
 

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -116,7 +116,7 @@ async def get_normalized_node_handler(curies: CurieList):
     """
     Get value(s) for key(s) using redis MGET
     """
-    normalized_nodes = await get_normalized_nodes(app, curies.curies, True)
+    normalized_nodes = await get_normalized_nodes(app, curies.curies, curies.conflate)
 
     return normalized_nodes
 

--- a/redis_config.yaml
+++ b/redis_config.yaml
@@ -1,6 +1,7 @@
 "eq_id_to_id_db" :
   "ssl_enabled": false
   "is_cluster": false
+  "db": 0
   "hosts":
     # list of cluster member ips and ports
     - "host_name": "127.0.0.1"
@@ -9,6 +10,7 @@
 "id_to_eqids_db":
   "ssl_enabled": false
   "is_cluster": false
+  "db": 1
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"
@@ -16,6 +18,7 @@
 "id_to_type_db":
   "ssl_enabled": false
   "is_cluster": false
+  "db": 2
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"
@@ -23,7 +26,15 @@
 "curie_to_bl_type_db":
   "ssl_enabled": false
   "is_cluster": false
-  "db": 1
+  "db": 3
+  "hosts":
+    - "host_name": "127.0.0.1"
+      "port": "6379"
+  "password": ""
+"gene_protein_db":
+  "ssl_enabled": false
+  "is_cluster": false
+  "db": 4
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"

--- a/redis_config.yaml
+++ b/redis_config.yaml
@@ -1,23 +1,30 @@
 "eq_id_to_id_db" :
   "ssl_enabled": false
-  "is_cluster": true
+  "is_cluster": false
   "hosts":
     # list of cluster member ips and ports
-    - "host_name": ""
+    - "host_name": "127.0.0.1"
       "port": "6379"
   "password": ""
-"id_to_data_db":
+"id_to_eqids_db":
   "ssl_enabled": false
-  "is_cluster": true
+  "is_cluster": false
   "hosts":
-    - "host_name": ""
+    - "host_name": "127.0.0.1"
+      "port": "6379"
+  "password": ""
+"id_to_type_db":
+  "ssl_enabled": false
+  "is_cluster": false
+  "hosts":
+    - "host_name": "127.0.0.1"
       "port": "6379"
   "password": ""
 "curie_to_bl_type_db":
   "ssl_enabled": false
   "is_cluster": false
   "db": 1
-  "host":
-    "host_name": ""
-    "port": "6379"
+  "hosts":
+    - "host_name": "127.0.0.1"
+      "port": "6379"
   "password": ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyyaml~=5.4.1
 requests~=2.25.1
 starlette==0.14.2
 redis-py-cluster==2.1.3
+bmt


### PR DESCRIPTION
This PR:
* Changes the redis storage.  db1 has been split into db2 and db3, with equivalent ids going into 2 and types going into 3
* Modified the equivalent ids to have "i" and "l" as keys to save space
* Only kept the most leaf type in db3.  This also saves space, but is really to set up for conflation
* Moved db3->db4
* Added a gene/protein conflation db, db5.
* Updated loader to read conflation files
* On normalize, db5 is hit to figure out other entities to merge in

The GET and POST get_normalized_nodes now take a conflate boolean argument.    If it is false, then the results are as they were.  If it is true, it consults db5 and if it can, it merged gene and protein nodes.

A few notes:
1. I don't really like how the redis dbs are being managed currently.   It seems that knowing which db is which is kind of all over the code.   There are some attempts to give the different dbs names, but then we look up the connections by number all the time.
2. On a similar plane, we have to define things in both configuration and code.   I think that all the redis setup should be driven off the config files, and the connections should be used by name in code.
3. I may have messed up the redis config file in terms of clusters; something may need to be cleaned/reverted?
4. /scratch/bizon/babel_outputs now contains all new-style compendia and conflation outputs
5. The current code only conflates genes and proteins, but we'll have a series of conflations, and I think we will want the option to independently turn them on or off during a normalization.  So I think that the conflate True/False will have to change to a list of allowed or denied conflations.
6. There may be room to optimize when we hit different conflation dbs; right now we are doing the simplest thing and always looking in it, whether the input is a gene/protein or something that would never be in that db.