### PR TITLE
Fix issue #113

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Create a virtual environment
 ```
 Activate the virtual environment
 ```
-    source nodeNodemaization-env/bin/activate
+    source nodeNormalization-env/bin/activate
 ```
 Install requirements 
 ```

--- a/node_normalizer/model/input.py
+++ b/node_normalizer/model/input.py
@@ -12,7 +12,8 @@ class CurieList(BaseModel):
 
     curies: List[str] = Field(
         ...,  # Ellipsis means field is required
-        title='list of nodes formatted as curies'
+        title='list of nodes formatted as curies',
+        min_items=1
     )
 
     conflate:bool = Field (

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -414,6 +414,10 @@ async def get_info_content(
     :param canonical_nonan:
     :return:
     """
+    # Check to see if canonical_nonan is not empty.
+    if not canonical_nonan:
+        return {}
+
     # call redis and get the value
     info_contents = await app.state.redis_connection4.mget(*canonical_nonan, encoding='utf8')
 

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -471,7 +471,7 @@ async def get_normalized_nodes(
         # did we get some canonical ids
         if canonical_nonan:
             # get the information content values
-            await get_info_content(app, canonical_nonan)
+            info_contents = await get_info_content(app, canonical_nonan)
 
             # Get the equivalent_ids and types
             eqids, types = await get_eqids_and_types(app, canonical_nonan)

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -462,11 +462,13 @@ async def get_normalized_nodes(
     try:
         canonical_ids = await app.state.redis_connection0.mget(*upper_curies, encoding='utf-8')
         canonical_nonan = [canonical_id for canonical_id in canonical_ids if canonical_id is not None]
-        # get the information content values
-        info_contents = await get_info_content(app, canonical_nonan)
+        info_contents = {}
 
         # did we get some canonical ids
         if canonical_nonan:
+            # get the information content values
+            await get_info_content(app, canonical_nonan)
+
             # Get the equivalent_ids and types
             eqids, types = await get_eqids_and_types(app, canonical_nonan)
 

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -105,12 +105,17 @@ async def get_conflations() -> ConflationList:
     summary='Get the equivalent identifiers and semantic types for the curie(s) entered.',
     description='Returns the equivalent identifiers and semantic types for the curie(s)'
 )
-async def get_normalized_node_handler(curie: List[str] = Query([], example=['MESH:D014867', 'NCIT:C34373']), conflate: bool = True):
+async def get_normalized_node_handler(curie: List[str] = Query([], example=['MESH:D014867', 'NCIT:C34373'], min_items=1), conflate: bool = True):
     """
     Get value(s) for key(s) using redis MGET
     """
     # no_conflate = request.args.get('dontconflate',['GeneProtein'])
     normalized_nodes = await get_normalized_nodes(app, curie, conflate)
+
+    # If curie contains at least one entry, then the only way normalized_nodes could be blank
+    # would be if an error occurred during processing.
+    if not normalized_nodes:
+        raise HTTPException(detail='Error occurred during processing.', status_code=500)
 
     return normalized_nodes
 
@@ -125,6 +130,11 @@ async def get_normalized_node_handler(curies: CurieList):
     Get value(s) for key(s) using redis MGET
     """
     normalized_nodes = await get_normalized_nodes(app, curies.curies, curies.conflate)
+
+    # If curies.curies contains at least one entry, then the only way normalized_nodes could be blank
+    # would be if an error occurred during processing.
+    if not normalized_nodes:
+        raise HTTPException(detail='Error occurred during processing.', status_code=500)
 
     return normalized_nodes
 

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -62,3 +62,19 @@ def test_empty():
     response = client.post('/get_normalized_nodes', json={"curies": []})
     result = json.loads(response.text)
     assert result == dict()
+
+
+def test_without_resolvable_curies():
+    """
+    /get_normalized_nodes previously returned {} if none of the provided CURIEs are resolvable.
+    This test ensures that that bug has been fixed.
+
+    Reported in https://github.com/TranslatorSRI/NodeNormalization/issues/113
+    """
+    client = TestClient(app)
+    response = client.get('/get_normalized_nodes', params={"curies": ["NCBIGene:ABCD", "NCBIGene:GENE:1017"]})
+    result = json.loads(response.text)
+    assert result == {
+        'NCBIGene:ABCD': None,
+        'NCBIGene:GENE:1017': None
+    }

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -83,10 +83,20 @@ def test_merge():
 
 def test_empty():
     client = TestClient(app)
+
+    # GET
     response = client.get('/get_normalized_nodes', params={"curie": []})
+    assert response.status_code == 422
+    assert response.reason == 'Unprocessable Entity'
     result = json.loads(response.text)
-    assert result == dict()
+    assert result['detail'][0]['msg'] == 'ensure this value has at least 1 items'
+    assert result['detail'][0]['loc'] == ['query', 'curie']
+
+    # POST
     response = client.post('/get_normalized_nodes', json={"curies": []})
+    assert response.status_code == 422
+    assert response.reason == 'Unprocessable Entity'
     result = json.loads(response.text)
-    assert result == dict()
+    assert result['detail'][0]['msg'] == 'ensure this value has at least 1 items'
+    assert result['detail'][0]['loc'] == ['body', 'curies']
 

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -72,7 +72,17 @@ def test_without_resolvable_curies():
     Reported in https://github.com/TranslatorSRI/NodeNormalization/issues/113
     """
     client = TestClient(app)
-    response = client.get('/get_normalized_nodes', params={"curies": ["NCBIGene:ABCD", "NCBIGene:GENE:1017"]})
+
+    # Test GET
+    response = client.get('/get_normalized_nodes', params={"curie": ["NCBIGene:ABCD", "NCBIGene:GENE:1017"]})
+    result = json.loads(response.text)
+    assert result == {
+        'NCBIGene:ABCD': None,
+        'NCBIGene:GENE:1017': None
+    }
+
+    # Test POST
+    response = client.post('/get_normalized_nodes', json={"curies": ["NCBIGene:ABCD", "NCBIGene:GENE:1017"]})
     result = json.loads(response.text)
     assert result == {
         'NCBIGene:ABCD': None,

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -45,26 +45,8 @@ def test_one_missing():
     assert result['UNKNOWN:000000'] == None
     assert result['DOID:3812']['id']['identifier'] == 'MONDO:0005002'
 
-def test_merge():
-    client = TestClient(app)
-    response = client.get('/get_normalized_nodes', params={"curie": ["MONDO:0005002", "DOID:3812"]})
-    result = json.loads(response.text)
-    assert len(result) == 2
-    assert 'MONDO:0005002' in result
-    assert 'DOID:3812' in result
 
-
-def test_empty():
-    client = TestClient(app)
-    response = client.get('/get_normalized_nodes', params={"curie": []})
-    result = json.loads(response.text)
-    assert result == dict()
-    response = client.post('/get_normalized_nodes', json={"curies": []})
-    result = json.loads(response.text)
-    assert result == dict()
-
-
-def test_without_resolvable_curies():
+def test_all_missing():
     """
     /get_normalized_nodes previously returned {} if none of the provided CURIEs are resolvable.
     This test ensures that that bug has been fixed.
@@ -88,3 +70,23 @@ def test_without_resolvable_curies():
         'NCBIGene:ABCD': None,
         'NCBIGene:GENE:1017': None
     }
+
+
+def test_merge():
+    client = TestClient(app)
+    response = client.get('/get_normalized_nodes', params={"curie": ["MONDO:0005002", "DOID:3812"]})
+    result = json.loads(response.text)
+    assert len(result) == 2
+    assert 'MONDO:0005002' in result
+    assert 'DOID:3812' in result
+
+
+def test_empty():
+    client = TestClient(app)
+    response = client.get('/get_normalized_nodes', params={"curie": []})
+    result = json.loads(response.text)
+    assert result == dict()
+    response = client.post('/get_normalized_nodes', json={"curies": []})
+    result = json.loads(response.text)
+    assert result == dict()
+


### PR DESCRIPTION
This PR adds a test for #113 -- a query containing only unresolvable curies will receive an empty response. This was happening because of two different reasons:
1. `get_info_content()` would throw an exception if given an empty list of canonical IDs. I moved the function call so that it would not be called with an empty list, and additionally modified the function so that it would return an empty dictionary if somebody did call it with an empty list from elsewhere.
2. `get_normalized_nodes()` would return `{}` if an exception was thrown inside much of the function. I've added checks to the GET and POST endpoints so that:
   1. They send an HTTP 422 Unprocessable Entity response if no CURIEs are provided.
   2. They send an HTTP 500 response if `get_normalized_nodes()` returns `{}`
   
This PR adds a test for queries without any resolvable CURIEs and updated the test for queries without any CURIEs at all.

Also fixes a minor typo in the README file.