### PR TITLE
Improve POST documentation

### DIFF
--- a/node_normalizer/model/input.py
+++ b/node_normalizer/model/input.py
@@ -16,7 +16,7 @@ class CurieList(BaseModel):
         min_items=1
     )
 
-    conflate:bool = Field (
+    conflate:bool = Field(
         True,
         title="Whether to apply conflation"
     )
@@ -24,7 +24,8 @@ class CurieList(BaseModel):
     class Config:
         schema_extra = {
             "example": {
-                "curies": ['MESH:D014867', 'NCIT:C34373']
+                "curies": ['MESH:D014867', 'NCIT:C34373'],
+                "conflate": True
             }
         }
 

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -105,7 +105,10 @@ async def get_conflations() -> ConflationList:
     summary='Get the equivalent identifiers and semantic types for the curie(s) entered.',
     description='Returns the equivalent identifiers and semantic types for the curie(s)'
 )
-async def get_normalized_node_handler(curie: List[str] = Query([], example=['MESH:D014867', 'NCIT:C34373'], min_items=1), conflate: bool = True):
+async def get_normalized_node_handler(
+    curie: List[str] = Query([], description="List of curies to normalize", example=['MESH:D014867', 'NCIT:C34373'], min_items=1),
+    conflate: bool = Query(True, description="Whether to apply conflation")
+):
     """
     Get value(s) for key(s) using redis MGET
     """
@@ -123,7 +126,7 @@ async def get_normalized_node_handler(curie: List[str] = Query([], example=['MES
 @app.post(
     '/get_normalized_nodes',
     summary='Get the equivalent identifiers and semantic types for the curie(s) entered.',
-    description='Returns the equivalent identifiers and semantic types for the curie(s)'
+    description='Returns the equivalent identifiers and semantic types for the curie(s). Use the `conflate` flag to choose whether to apply conflation.'
 )
 async def get_normalized_node_handler(curies: CurieList):
     """


### PR DESCRIPTION
This PR improves the example for the POST `/get_normalized_nodes` endpoint to include a reference to the `conflate` flag. It also add descriptions to the two parameters for the GET `/get_normalized_nodes` endpoint.

Closes #90.