### PR TITLE
Redis cluster loader fix

### DIFF
--- a/node_normalizer/loader.py
+++ b/node_normalizer/loader.py
@@ -288,7 +288,8 @@ class NodeLoader:
             meta_data = await meta_data
         all_meta_data = {}
         for meta_data_key, meta_datum in zip(meta_data_keys, meta_data):
-            all_meta_data[meta_data_key.decode('utf-8')] = json.loads(meta_datum.decode('utf-8'))
+            if meta_datum:
+                all_meta_data[meta_data_key.decode('utf-8')] = json.loads(meta_datum.decode('utf-8'))
         sources_prefix = {}
         for meta_data_key, data in all_meta_data.items():
             prefix_counts = data['source_prefixes']

--- a/node_normalizer/loader.py
+++ b/node_normalizer/loader.py
@@ -273,13 +273,7 @@ class NodeLoader:
         # get the connection and pipeline to the database
 
         types_prefixes_redis: RedisConnection = await self.get_redis("curie_to_bl_type_db")
-        types_prefixes_pipeline = types_prefixes_redis.pipeline()
-        # get all metadata keys
-        types_prefixes_pipeline.keys("file-*")
-        meta_data_keys = types_prefixes_pipeline.execute()
-        if asyncio.coroutines.iscoroutine(meta_data_keys):
-            meta_data_keys = await meta_data_keys
-
+        meta_data_keys = await types_prefixes_redis.keys("file-*")
         # recreate pipeline
 
         types_prefixes_pipeline = types_prefixes_redis.pipeline()

--- a/node_normalizer/redis_adapter.py
+++ b/node_normalizer/redis_adapter.py
@@ -134,6 +134,18 @@ class RedisConnection:
     def pipeline(self):
         return self.connector.pipeline()
 
+    def keys(self, pattern, encoding="utf-8"):
+        """
+        Execute keys command
+        :param str:
+        :return:
+        """
+        if isinstance(self.connector, RedisCluster):
+            self.connector: RedisCluster
+            return self.connector.keys(pattern=pattern)
+        elif isinstance(self.connector, aioredis.commands.Redis):
+            self.connector: aioredis.commands.Redis
+            return await self.connector.keys(pattern=pattern, encoding=encoding)
     @staticmethod
     def reset_pipeline(pipeline):
         if isinstance(pipeline, aioredis.commands.transaction.Pipeline):

--- a/node_normalizer/redis_adapter.py
+++ b/node_normalizer/redis_adapter.py
@@ -134,7 +134,7 @@ class RedisConnection:
     def pipeline(self):
         return self.connector.pipeline()
 
-    def keys(self, pattern, encoding="utf-8"):
+    async def keys(self, pattern, encoding="utf-8"):
         """
         Execute keys command
         :param str:


### PR DESCRIPTION
Recent changes to loader introduced a bug in cluster env. 

```

  File "/code/node_normalizer/loader.py", line 260, in load
    await self.merge_semantic_meta_data()
  File "/code/node_normalizer/loader.py", line 278, in merge_semantic_meta_data
    types_prefixes_pipeline.keys("file-*")
  File "/usr/local/lib/python3.9/site-packages/rediscluster/pipeline.py", line 331, in inner
    raise RedisClusterException("ERROR: Calling pipelined function {0} is blocked when running redis in cluster mode...".format(func.__name__))
rediscluster.exceptions.RedisClusterException: ERROR: Calling pipelined function keys is blocked when running redis in cluster mode...
```

This is due to usage of "keys" on pipeline object of a cluster connection. 

This PR adds keys command to the redis-connection object , so we don't have to call it via a pipeline. 