### PR TITLE
Replace status badge in README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'Release a new version to Github Packages'
+name: 'Publish to GitHub Packages'
 
 on:
     release:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/TranslatorIIPrototypes/NodeNormalization.svg?branch=master)](https://travis-ci.com/TranslatorIIPrototypes/NodeNormalization)
+[![Publish to GitHub Packages](https://github.com/TranslatorSRI/NodeNormalization/actions/workflows/release.yml/badge.svg)](https://github.com/TranslatorSRI/NodeNormalization/actions/workflows/release.yml)
 
 # NodeNormalization
 


### PR DESCRIPTION
The status badge in README still pointed to Travis CI. This changes it to point to the "Publish to GitHub Packages" GitHub Action instead.