### PR TITLE
Updated version from v2.0.10 to v2.1.1

### DIFF
--- a/node_normalizer/resources/openapi.yml
+++ b/node_normalizer/resources/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Node Normalization
-  version: 2.0.10
+  version: 2.1.1
   contact:
     email: bizon@renci.org
     name: Chris Bizon


### PR DESCRIPTION
This PR simply updates the version number of NodeNorm from v2.0.10 to v2.1.1, something I forgot to do when I released v2.1.0.

Once this PR has been accepted, I'll tag this as v2.1.1 and use that to trigger a new GitHub release.