### PR TITLE
Workaround for missing type information

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: 'Publish to GitHub Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: 'Publish to GitHub Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -13,7 +13,7 @@ from bmt.util import format as bmt_format
 from fastapi import FastAPI
 from reasoner_pydantic import KnowledgeGraph, Message, QueryGraph, Result, CURIE, Attribute
 
-from .util import LoggingUtil, uniquify_list
+from .util import LoggingUtil, uniquify_list, BIOLINK_NAMED_THING
 
 # logger = LoggingUtil.init_logging(__name__, level=logging.INFO, format='medium', logFilePath=os.path.dirname(__file__), logFileLevel=logging.INFO)
 logger = LoggingUtil.init_logging()
@@ -491,8 +491,9 @@ async def get_eqids_and_types(
     types_with_ancestors = []
     for index, typ in enumerate(types):
         if not typ:
-            logging.error(f"No type information found for '{canonical_nonan[index]}' with eqids: {eqids[index]}.")
-            types_with_ancestors.append([None])
+            logging.error(f"No type information found for '{canonical_nonan[index]}' with eqids: {eqids[index]}, "
+                          f"replacing with {BIOLINK_NAMED_THING}")
+            types_with_ancestors.append([BIOLINK_NAMED_THING])
         else:
             types_with_ancestors.append(get_ancestors(app, typ))
     return eqids, types_with_ancestors

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -486,7 +486,7 @@ async def get_eqids_and_types(
     eqids = []
     for i in range(0, len(canonical_nonan), batch_size):
         eqids += await app.state.redis_connection1.mget(*canonical_nonan[i:i+batch_size], encoding='utf-8')
-    eqids = [json.loads(value) if value is not None else None for value in eqids]
+    eqids = [json.loads(value) if value is not None else [None] for value in eqids]
     types = await app.state.redis_connection2.mget(*canonical_nonan, encoding='utf-8')
     types_with_ancestors = []
     for index, typ in enumerate(types):

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -646,7 +646,8 @@ async def create_node(canonical_id, equivalent_ids, types, info_contents, includ
     if canonical_id is None:
         return None
 
-    # If we have 'None' in the canonical types, something went horribly wrong. Return None.
+    # If we have 'None' in the canonical types, something went horribly wrong (specifically: we couldn't
+    # find the type information for all the eqids for this clique). Return None.
     if None in types[canonical_id]:
         return None
 

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -648,10 +648,13 @@ async def create_node(canonical_id, equivalent_ids, types, info_contents, includ
     if canonical_id is None:
         return None
 
-    # If we have 'None' in the equivalent IDs, something has gone horrible wrong. Return None.
+    # If we have 'None' in the equivalent IDs, skip it so we don't confuse things further down the line.
     if None in equivalent_ids[canonical_id]:
-        logging.error(f"No equivalent IDs found for canonical ID {canonical_id} among eqids: {equivalent_ids}")
-        return None
+        logging.warning(f"Skipping None in canonical ID {canonical_id} among eqids: {equivalent_ids}")
+        equivalent_ids[canonical_id] = [x for x in equivalent_ids[canonical_id] if x is not None]
+        if not equivalent_ids[canonical_id]:
+            logging.warning(f"No non-None values found for ID {canonical_id} among filtered eqids: {equivalent_ids}")
+            return None
 
     # If we have 'None' in the canonical types, something went horribly wrong (specifically: we couldn't
     # find the type information for all the eqids for this clique). Return None.

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -588,8 +588,10 @@ async def get_normalized_nodes(
                         t = []
 
                     for other in dereference_others[canonical_id]:
-                        e += deref_others_eqs[other]
-                        t += deref_others_typ[other]
+                        if deref_others_eqs[other]:
+                            e += deref_others_eqs[other]
+                        if deref_others_typ[other]:
+                            t += deref_others_typ[other]
 
                     final_eqids.append(e)
                     final_types.append(uniquify_list(t))
@@ -644,6 +646,10 @@ async def create_node(canonical_id, equivalent_ids, types, info_contents, includ
     """Construct the output format given the compressed redis data"""
     # It's possible that we didn't find a canonical_id
     if canonical_id is None:
+        return None
+
+    # If we have 'None' in the equivalent IDs, something has gone horrible wrong. Return None.
+    if None in equivalent_ids[canonical_id]:
         return None
 
     # If we have 'None' in the canonical types, something went horribly wrong (specifically: we couldn't

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -588,6 +588,7 @@ async def get_normalized_nodes(
                         t = []
 
                     for other in dereference_others[canonical_id]:
+                        logging.error(f"e = {e}, other = {other}, deref_others_eqs = {deref_others_eqs}")
                         e += deref_others_eqs[other]
                         t += deref_others_typ[other]
 

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -588,7 +588,7 @@ async def get_normalized_nodes(
                         t = []
 
                     for other in dereference_others[canonical_id]:
-                        logging.error(f"e = {e}, other = {other}, deref_others_eqs = {deref_others_eqs}")
+                        # logging.debug(f"e = {e}, other = {other}, deref_others_eqs = {deref_others_eqs}")
                         e += deref_others_eqs[other]
                         t += deref_others_typ[other]
 

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -492,7 +492,7 @@ async def get_eqids_and_types(
     for index, typ in enumerate(types):
         if not typ:
             logging.error(f"No type information found for '{canonical_nonan[index]}' with eqids: {eqids[index]}.")
-            types_with_ancestors.append(None)
+            types_with_ancestors.append([None])
         else:
             types_with_ancestors.append(get_ancestors(app, typ))
     return eqids, types_with_ancestors
@@ -588,10 +588,8 @@ async def get_normalized_nodes(
                         t = []
 
                     for other in dereference_others[canonical_id]:
-                        if deref_others_eqs[other]:
-                            e += deref_others_eqs[other]
-                        if deref_others_typ[other]:
-                            t += deref_others_typ[other]
+                        e += deref_others_eqs[other]
+                        t += deref_others_typ[other]
 
                     final_eqids.append(e)
                     final_types.append(uniquify_list(t))

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -650,11 +650,13 @@ async def create_node(canonical_id, equivalent_ids, types, info_contents, includ
 
     # If we have 'None' in the equivalent IDs, something has gone horrible wrong. Return None.
     if None in equivalent_ids[canonical_id]:
+        logging.error(f"No equivalent IDs found for canonical ID {canonical_id} among eqids: {equivalent_ids}")
         return None
 
     # If we have 'None' in the canonical types, something went horribly wrong (specifically: we couldn't
     # find the type information for all the eqids for this clique). Return None.
     if None in types[canonical_id]:
+        logging.error(f"No types found for canonical ID {canonical_id} among types: {types}")
         return None
 
     # OK, now we should have id's in the format [ {"i": "MONDO:12312", "l": "Scrofula"}, {},...]

--- a/node_normalizer/util.py
+++ b/node_normalizer/util.py
@@ -8,6 +8,9 @@ from logging.config import dictConfig
 from logging.handlers import RotatingFileHandler
 from fastapi.logger import logger as fastapi_logger
 
+# Some constants.
+BIOLINK_NAMED_THING = "biolink:NamedThing"
+
 
 # loggers = {}
 class LoggingUtil(object):


### PR DESCRIPTION
This PR provides a workaround for #221 by:
- Logging an error when an ID doesn't have type information for some reason.
- Reporting such an identifier back to the user as not found, without causing the entire batch to fail (closes #222)
- Assuming that any identifier missing type information can be assumed to be a `biolink:NamedThing` (closes #221).

Closes #221.

