### PR TITLE
Add NodeNorm-Loader Docker

### DIFF
--- a/.github/workflows/release-loading.yml
+++ b/.github/workflows/release-loading.yml
@@ -1,6 +1,7 @@
 name: 'Publish nodenorm-loading to GitHub Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-loading.yml
+++ b/.github/workflows/release-loading.yml
@@ -1,7 +1,6 @@
 name: 'Publish nodenorm-loading to GitHub Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/.github/workflows/release-loading.yml
+++ b/.github/workflows/release-loading.yml
@@ -1,0 +1,46 @@
+name: 'Publish nodenorm-loading to GitHub Packages'
+
+on:
+    release:
+        types: [published]
+
+env:
+    REGISTRY: ghcr.io
+
+jobs:
+    push_to_registry:
+        name: Push Docker image for NodeNorm loading to GitHub Packages tagged with "latest" and version number.
+        runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          packages: write
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v2
+            - name: Get the version
+              id: get_version
+              run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                images:
+                    ghcr.io/${{ github.repository }}-data-loading
+            - name: Login to ghcr
+              uses: docker/login-action@v1
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            # Setting up Docker Buildx with docker-container driver is required
+            # at the moment to be able to use a subdirectory with Git context
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+            - name: Push to GitHub Packages
+              uses: docker/build-push-action@v4
+              with:
+                  context: "{{defaultContext}}:data-loading"
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  build-args: BRANCH_NAME=${{ github.event.release.target_commitish }}

--- a/.github/workflows/release-loading.yml
+++ b/.github/workflows/release-loading.yml
@@ -27,6 +27,7 @@ jobs:
               with:
                 images:
                     ghcr.io/${{ github.repository }}-data-loading
+            # This will leave authentication information, but that shouldn't be relevant here.
             - name: Login to ghcr
               uses: docker/login-action@v1
               with:

--- a/.github/workflows/release-loading.yml
+++ b/.github/workflows/release-loading.yml
@@ -17,7 +17,7 @@ jobs:
           packages: write
         steps:
             - name: Check out the repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
             - name: Get the version
               id: get_version
               run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/data-loading/Dockerfile
+++ b/data-loading/Dockerfile
@@ -1,0 +1,36 @@
+# Use Redis so we can redis-cli.
+FROM redis:7
+
+# Configuration
+ARG ROOT=/home/nru
+ARG DATA=/data
+
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get -y install wget python3-venv python3-pip
+
+# Create nru user
+RUN mkdir -p ${ROOT}
+RUN useradd nru -d ${ROOT}
+RUN chown nru ${ROOT}
+WORKDIR ${ROOT}
+
+# Set up a volume for data.
+VOLUME ${DATA}
+RUN mkdir -p ${DATA}
+RUN chown nru ${DATA}
+
+# Switch to nru user.
+USER nru
+
+# Set up VENV
+ENV VIRTUAL_ENV=${ROOT}/venv
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
+
+# Install requirements.
+COPY --chown=nru requirements.txt ${ROOT}
+RUN pip3 install -r requirements.txt
+
+# Entrypoint should be bash.
+ENTRYPOINT /bin/bash

--- a/data-loading/README.md
+++ b/data-loading/README.md
@@ -1,0 +1,9 @@
+# NodeNorm Data Loader
+
+This directory holds a Dockerfile that we need to set up a Redis pipe
+node on Kubernetes. It doesn't actually need very much, but putting it
+in here allows us to automatically generate it through GitHub Actions
+whenever there is a new NodeNorm release.
+
+See https://github.com/helxplatform/translator-devops/pull/768 for
+information on how this container will be used.

--- a/data-loading/requirements.txt
+++ b/data-loading/requirements.txt
@@ -1,0 +1,2 @@
+rdbtools
+python-lzf


### PR DESCRIPTION
I've written a new NodeNorm Loader in Translator-Devops as PR https://github.com/helxplatform/translator-devops/pull/768 -- a script that allows NodeNorm data to be loaded into a Redis server by piping it directly from a Redis RDB file. To do this, we need a Docker instance that includes both redis-cli and [redis-rdb-tools](https://github.com/sripathikrishnan/redis-rdb-tools). I've created that Docker image here, and added a GitHub Action to produce and publish that Docker package in this repository every time we publish a new version of NodeNorm.