### PR TITLE
Fix missing node bindings in NodeNorm /query output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: 'Publish to GitHub Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: 'Publish to GitHub Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -43,16 +43,21 @@ async def normalize_message(app: FastAPI, message: Message) -> Message:
         if message.query_graph is not None:
             merged_qgraph = await normalize_qgraph(app, message.query_graph)
             ret.query_graph = merged_qgraph
+        logger.debug(f"Merged Qgraph: {merged_qgraph}")
 
         logger.debug(f"message.knowledge_graph is None: {message.knowledge_graph is None}")
         if message.knowledge_graph is not None:
             merged_kgraph, node_id_map, edge_id_map = await normalize_kgraph(app, message.knowledge_graph)
             ret.knowledge_graph = merged_kgraph
+        logger.debug(f"Merged Kgraph: {merged_kgraph}")
+        logger.debug(f"node_id_map: {node_id_map}")
+        logger.debug(f"edge_id_map: {edge_id_map}")
 
         logger.debug(f"message.results is None: {message.results is None}")
         if message.results is not None:
             merged_results = await normalize_results(app, message.results, node_id_map, edge_id_map)
             ret.results = merged_results
+        logger.debug(f"Merged Results: {merged_results}")
 
         return ret
     except Exception as e:

--- a/node_normalizer/normalizer.py
+++ b/node_normalizer/normalizer.py
@@ -98,7 +98,7 @@ async def normalize_results(app,
 
                     # did we get a good attribute dict
                     if ic_attrib:
-                        if 'attributes' in merged_binding:
+                        if 'attributes' in merged_binding and merged_binding['attributes'] is not None:
                             merged_binding['attributes'].append(ic_attrib)
                         else:
                             merged_binding['attributes'] = [ic_attrib]

--- a/node_normalizer/resources/openapi.yml
+++ b/node_normalizer/resources/openapi.yml
@@ -33,6 +33,8 @@ info:
 servers:
   - description: Default server
     url: https://nodenormalization-sri.renci.org/
+  - description: Localhost
+    url: http://localhost:2434/
 
 tags:
   - name: translator


### PR DESCRIPTION
As reported in #229. As far as I can tell, this was caused by merged_binding being None, which could cause it to end up being an object later in the code. Handling the case where it's None appears to fix this problem as per the simple test in PR https://github.com/TranslatorSRI/babel-validation/pull/26.

Fixes #229.