### PR TITLE
Remove hardcoded TRAPI version

### DIFF
--- a/node_normalizer/apidocs.py
+++ b/node_normalizer/apidocs.py
@@ -71,7 +71,7 @@ def construct_open_api_schema(app) -> Dict[str, str]:
     if 'servers' in api_docs:
         for s in api_docs['servers']:
             # override if server root env var is provided
-            s['url'] = server_root + '1.4' if server_root != '/' else s['url']
+            s['url'] = server_root + os.environ.get("TRAPI_VERSION", "1.4") if server_root != '/' else s['url']
             s['x-maturity'] = os.environ.get("MATURITY_VALUE", "maturity")
             s['x-location'] = os.environ.get("LOCATION_VALUE", "location")
         open_api_schema['servers'] = api_docs['servers']

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -45,7 +45,7 @@ loader = NodeLoader()
 
 redis_host = os.environ.get("REDIS_HOST", loader.get_config()["redis_host"])
 redis_port = os.environ.get("REDIS_PORT", loader.get_config()["redis_port"])
-TRAPI_VERSION = os.environ.get("TRAPI_VERSION", "1.3")
+TRAPI_VERSION = os.environ.get("TRAPI_VERSION", "1.4")
 
 async_query_tasks = set()
 


### PR DESCRIPTION
This PR removes references to TRAPI 1.3 and replaces a hardcoded reference to TRAPI 1.4 with the value of the TRAPI_VERSION environmental variable.

Closes #215.