### PR TITLE
Reverted NodeNorm-loader to Redis v6

### DIFF
--- a/data-loading/Dockerfile
+++ b/data-loading/Dockerfile
@@ -1,5 +1,5 @@
 # Use Redis so we can redis-cli.
-FROM redis:7
+FROM redis:6
 
 # Configuration
 ARG ROOT=/home/nru


### PR DESCRIPTION
NodeNorm-loader currently uses Redis v7 (because I assumed this would be the latest and greatest), but this might be having difficulty communicating properly with ITRB clusters which currently run Redis v6. So this PR updates NodeNorm-loader to use Redis v6 instead.

Might help with https://github.com/helxplatform/translator-devops/issues/813