### PR TITLE
Improve POST /query example

### DIFF
--- a/node_normalizer/examples.py
+++ b/node_normalizer/examples.py
@@ -1,0 +1,294 @@
+"""
+This file contains some examples that we can use to populate the OpenAPI documentation.
+"""
+
+EXAMPLE_QUERY_DRUG_TREATS_ESSENTIAL_HYPERTENSION = {
+    "message": {
+        "query_graph": {
+            "nodes": {
+                "n0": {
+                    "categories": ["biolink:Drug"],
+                    "is_set": False,
+                    "constraints": [],
+                },
+                "n1": {
+                    "ids": ["MONDO:0001134"],
+                    "categories": ["biolink:Disease"],
+                    "is_set": False,
+                    "constraints": [],
+                },
+            },
+            "edges": {
+                "e01": {
+                    "subject": "n0",
+                    "object": "n1",
+                    "predicates": ["biolink:treats"],
+                    "attribute_constraints": [],
+                    "qualifier_constraints": [],
+                }
+            },
+        },
+        "knowledge_graph": {
+            "nodes": {
+                "DRUGBANK:DB00275": {
+                    "categories": ["biolink:Drug"],
+                    "name": "Olmesartan",
+                },
+                "MONDO:0001134": {
+                    "categories": ["biolink:Disease"],
+                    "name": "essential hypertension",
+                },
+                "DRUGBANK:DB00876": {
+                    "categories": ["biolink:Drug"],
+                    "name": "Eprosartan",
+                },
+                "DRUGBANK:DB00177": {
+                    "categories": ["biolink:Drug"],
+                    "name": "Valsartan",
+                },
+                "DRUGBANK:DB00966": {
+                    "categories": ["biolink:Drug"],
+                    "name": "Telmisartan",
+                },
+                "DRUGBANK:DB00678": {
+                    "categories": ["biolink:Drug"],
+                    "name": "Losartan",
+                },
+            },
+            "edges": {
+                "e0": {
+                    "subject": "DRUGBANK:DB00275",
+                    "object": "MONDO:0001134",
+                    "predicate": "biolink:treats",
+                    "sources": [
+                        {
+                            "resource_id": "infores:openpredict",
+                            "resource_role": "primary_knowledge_source",
+                        },
+                        {
+                            "resource_id": "infores:cohd",
+                            "resource_role": "supporting_data_source",
+                        },
+                    ],
+                    "attributes": [
+                        {
+                            "description": "model_id",
+                            "attribute_type_id": "EDAM:data_1048",
+                            "value": "openpredict_baseline",
+                        },
+                        {
+                            "attribute_type_id": "biolink:agent_type",
+                            "value": "computational_model",
+                            "attribute_source": "infores:openpredict",
+                        },
+                        {
+                            "attribute_type_id": "biolink:knowledge_level",
+                            "value": "prediction",
+                            "attribute_source": "infores:openpredict",
+                        },
+                    ],
+                },
+                "e1": {
+                    "subject": "DRUGBANK:DB00876",
+                    "object": "MONDO:0001134",
+                    "predicate": "biolink:treats",
+                    "sources": [
+                        {
+                            "resource_id": "infores:openpredict",
+                            "resource_role": "primary_knowledge_source",
+                        },
+                        {
+                            "resource_id": "infores:cohd",
+                            "resource_role": "supporting_data_source",
+                        },
+                    ],
+                    "attributes": [
+                        {
+                            "description": "model_id",
+                            "attribute_type_id": "EDAM:data_1048",
+                            "value": "openpredict_baseline",
+                        },
+                        {
+                            "attribute_type_id": "biolink:agent_type",
+                            "value": "computational_model",
+                            "attribute_source": "infores:openpredict",
+                        },
+                        {
+                            "attribute_type_id": "biolink:knowledge_level",
+                            "value": "prediction",
+                            "attribute_source": "infores:openpredict",
+                        },
+                    ],
+                },
+                "e2": {
+                    "subject": "DRUGBANK:DB00177",
+                    "object": "MONDO:0001134",
+                    "predicate": "biolink:treats",
+                    "sources": [
+                        {
+                            "resource_id": "infores:openpredict",
+                            "resource_role": "primary_knowledge_source",
+                        },
+                        {
+                            "resource_id": "infores:cohd",
+                            "resource_role": "supporting_data_source",
+                        },
+                    ],
+                    "attributes": [
+                        {
+                            "description": "model_id",
+                            "attribute_type_id": "EDAM:data_1048",
+                            "value": "openpredict_baseline",
+                        },
+                        {
+                            "attribute_type_id": "biolink:agent_type",
+                            "value": "computational_model",
+                            "attribute_source": "infores:openpredict",
+                        },
+                        {
+                            "attribute_type_id": "biolink:knowledge_level",
+                            "value": "prediction",
+                            "attribute_source": "infores:openpredict",
+                        },
+                    ],
+                },
+                "e3": {
+                    "subject": "DRUGBANK:DB00966",
+                    "object": "MONDO:0001134",
+                    "predicate": "biolink:treats",
+                    "sources": [
+                        {
+                            "resource_id": "infores:openpredict",
+                            "resource_role": "primary_knowledge_source",
+                        },
+                        {
+                            "resource_id": "infores:cohd",
+                            "resource_role": "supporting_data_source",
+                        },
+                    ],
+                    "attributes": [
+                        {
+                            "description": "model_id",
+                            "attribute_type_id": "EDAM:data_1048",
+                            "value": "openpredict_baseline",
+                        },
+                        {
+                            "attribute_type_id": "biolink:agent_type",
+                            "value": "computational_model",
+                            "attribute_source": "infores:openpredict",
+                        },
+                        {
+                            "attribute_type_id": "biolink:knowledge_level",
+                            "value": "prediction",
+                            "attribute_source": "infores:openpredict",
+                        },
+                    ],
+                },
+                "e4": {
+                    "subject": "DRUGBANK:DB00678",
+                    "object": "MONDO:0001134",
+                    "predicate": "biolink:treats",
+                    "sources": [
+                        {
+                            "resource_id": "infores:openpredict",
+                            "resource_role": "primary_knowledge_source",
+                        },
+                        {
+                            "resource_id": "infores:cohd",
+                            "resource_role": "supporting_data_source",
+                        },
+                    ],
+                    "attributes": [
+                        {
+                            "description": "model_id",
+                            "attribute_type_id": "EDAM:data_1048",
+                            "value": "openpredict_baseline",
+                        },
+                        {
+                            "attribute_type_id": "biolink:agent_type",
+                            "value": "computational_model",
+                            "attribute_source": "infores:openpredict",
+                        },
+                        {
+                            "attribute_type_id": "biolink:knowledge_level",
+                            "value": "prediction",
+                            "attribute_source": "infores:openpredict",
+                        },
+                    ],
+                },
+            },
+        },
+        "results": [
+            {
+                "node_bindings": {
+                    "n0": [{"id": "DRUGBANK:DB00275"}],
+                    "n1": [{"id": "MONDO:0001134"}],
+                },
+                "analyses": [
+                    {
+                        "resource_id": "infores:openpredict",
+                        "score": "0.8515367495059102",
+                        "scoring_method": "Model confidence between 0 and 1",
+                        "edge_bindings": {"e01": [{"id": "e0"}]},
+                    }
+                ],
+            },
+            {
+                "node_bindings": {
+                    "n0": [{"id": "DRUGBANK:DB00876"}],
+                    "n1": [{"id": "MONDO:0001134"}],
+                },
+                "analyses": [
+                    {
+                        "resource_id": "infores:openpredict",
+                        "score": "0.8361819712989409",
+                        "scoring_method": "Model confidence between 0 and 1",
+                        "edge_bindings": {"e01": [{"id": "e1"}]},
+                    }
+                ],
+            },
+            {
+                "node_bindings": {
+                    "n0": [{"id": "DRUGBANK:DB00177"}],
+                    "n1": [{"id": "MONDO:0001134"}],
+                },
+                "analyses": [
+                    {
+                        "resource_id": "infores:openpredict",
+                        "score": "0.8154221336665431",
+                        "scoring_method": "Model confidence between 0 and 1",
+                        "edge_bindings": {"e01": [{"id": "e2"}]},
+                    }
+                ],
+            },
+            {
+                "node_bindings": {
+                    "n0": [{"id": "DRUGBANK:DB00966"}],
+                    "n1": [{"id": "MONDO:0001134"}],
+                },
+                "analyses": [
+                    {
+                        "resource_id": "infores:openpredict",
+                        "score": "0.7155011411093821",
+                        "scoring_method": "Model confidence between 0 and 1",
+                        "edge_bindings": {"e01": [{"id": "e3"}]},
+                    }
+                ],
+            },
+            {
+                "node_bindings": {
+                    "n0": [{"id": "DRUGBANK:DB00678"}],
+                    "n1": [{"id": "MONDO:0001134"}],
+                },
+                "analyses": [
+                    {
+                        "resource_id": "infores:openpredict",
+                        "score": "0.682246949249408",
+                        "scoring_method": "Model confidence between 0 and 1",
+                        "edge_bindings": {"e01": [{"id": "e4"}]},
+                    }
+                ],
+            },
+        ],
+    }
+}

--- a/node_normalizer/examples.py
+++ b/node_normalizer/examples.py
@@ -30,22 +30,6 @@ EXAMPLE_QUERY_DRUG_TREATS_ESSENTIAL_HYPERTENSION = {
         },
         "knowledge_graph": {
             "nodes": {
-                "DRUGBANK:DB00275": {
-                    "categories": ["biolink:Drug"],
-                    "name": "Olmesartan",
-                },
-                "MONDO:0001134": {
-                    "categories": ["biolink:Disease"],
-                    "name": "essential hypertension",
-                },
-                "DRUGBANK:DB00876": {
-                    "categories": ["biolink:Drug"],
-                    "name": "Eprosartan",
-                },
-                "DRUGBANK:DB00177": {
-                    "categories": ["biolink:Drug"],
-                    "name": "Valsartan",
-                },
                 "DRUGBANK:DB00966": {
                     "categories": ["biolink:Drug"],
                     "name": "Telmisartan",
@@ -56,102 +40,6 @@ EXAMPLE_QUERY_DRUG_TREATS_ESSENTIAL_HYPERTENSION = {
                 },
             },
             "edges": {
-                "e0": {
-                    "subject": "DRUGBANK:DB00275",
-                    "object": "MONDO:0001134",
-                    "predicate": "biolink:treats",
-                    "sources": [
-                        {
-                            "resource_id": "infores:openpredict",
-                            "resource_role": "primary_knowledge_source",
-                        },
-                        {
-                            "resource_id": "infores:cohd",
-                            "resource_role": "supporting_data_source",
-                        },
-                    ],
-                    "attributes": [
-                        {
-                            "description": "model_id",
-                            "attribute_type_id": "EDAM:data_1048",
-                            "value": "openpredict_baseline",
-                        },
-                        {
-                            "attribute_type_id": "biolink:agent_type",
-                            "value": "computational_model",
-                            "attribute_source": "infores:openpredict",
-                        },
-                        {
-                            "attribute_type_id": "biolink:knowledge_level",
-                            "value": "prediction",
-                            "attribute_source": "infores:openpredict",
-                        },
-                    ],
-                },
-                "e1": {
-                    "subject": "DRUGBANK:DB00876",
-                    "object": "MONDO:0001134",
-                    "predicate": "biolink:treats",
-                    "sources": [
-                        {
-                            "resource_id": "infores:openpredict",
-                            "resource_role": "primary_knowledge_source",
-                        },
-                        {
-                            "resource_id": "infores:cohd",
-                            "resource_role": "supporting_data_source",
-                        },
-                    ],
-                    "attributes": [
-                        {
-                            "description": "model_id",
-                            "attribute_type_id": "EDAM:data_1048",
-                            "value": "openpredict_baseline",
-                        },
-                        {
-                            "attribute_type_id": "biolink:agent_type",
-                            "value": "computational_model",
-                            "attribute_source": "infores:openpredict",
-                        },
-                        {
-                            "attribute_type_id": "biolink:knowledge_level",
-                            "value": "prediction",
-                            "attribute_source": "infores:openpredict",
-                        },
-                    ],
-                },
-                "e2": {
-                    "subject": "DRUGBANK:DB00177",
-                    "object": "MONDO:0001134",
-                    "predicate": "biolink:treats",
-                    "sources": [
-                        {
-                            "resource_id": "infores:openpredict",
-                            "resource_role": "primary_knowledge_source",
-                        },
-                        {
-                            "resource_id": "infores:cohd",
-                            "resource_role": "supporting_data_source",
-                        },
-                    ],
-                    "attributes": [
-                        {
-                            "description": "model_id",
-                            "attribute_type_id": "EDAM:data_1048",
-                            "value": "openpredict_baseline",
-                        },
-                        {
-                            "attribute_type_id": "biolink:agent_type",
-                            "value": "computational_model",
-                            "attribute_source": "infores:openpredict",
-                        },
-                        {
-                            "attribute_type_id": "biolink:knowledge_level",
-                            "value": "prediction",
-                            "attribute_source": "infores:openpredict",
-                        },
-                    ],
-                },
                 "e3": {
                     "subject": "DRUGBANK:DB00966",
                     "object": "MONDO:0001134",
@@ -219,48 +107,6 @@ EXAMPLE_QUERY_DRUG_TREATS_ESSENTIAL_HYPERTENSION = {
             },
         },
         "results": [
-            {
-                "node_bindings": {
-                    "n0": [{"id": "DRUGBANK:DB00275"}],
-                    "n1": [{"id": "MONDO:0001134"}],
-                },
-                "analyses": [
-                    {
-                        "resource_id": "infores:openpredict",
-                        "score": "0.8515367495059102",
-                        "scoring_method": "Model confidence between 0 and 1",
-                        "edge_bindings": {"e01": [{"id": "e0"}]},
-                    }
-                ],
-            },
-            {
-                "node_bindings": {
-                    "n0": [{"id": "DRUGBANK:DB00876"}],
-                    "n1": [{"id": "MONDO:0001134"}],
-                },
-                "analyses": [
-                    {
-                        "resource_id": "infores:openpredict",
-                        "score": "0.8361819712989409",
-                        "scoring_method": "Model confidence between 0 and 1",
-                        "edge_bindings": {"e01": [{"id": "e1"}]},
-                    }
-                ],
-            },
-            {
-                "node_bindings": {
-                    "n0": [{"id": "DRUGBANK:DB00177"}],
-                    "n1": [{"id": "MONDO:0001134"}],
-                },
-                "analyses": [
-                    {
-                        "resource_id": "infores:openpredict",
-                        "score": "0.8154221336665431",
-                        "scoring_method": "Model confidence between 0 and 1",
-                        "edge_bindings": {"e01": [{"id": "e2"}]},
-                    }
-                ],
-            },
             {
                 "node_bindings": {
                     "n0": [{"id": "DRUGBANK:DB00966"}],

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -5,12 +5,12 @@ import traceback
 import logging, warnings
 
 from pathlib import Path
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Annotated
 from fastapi.middleware.cors import CORSMiddleware
 import requests
 from requests.adapters import HTTPAdapter, Retry
 import fastapi
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Body, Query
 import reasoner_pydantic
 from bmt import Toolkit
 from starlette.responses import JSONResponse
@@ -27,6 +27,7 @@ from .model import (
 from .normalizer import get_normalized_nodes, get_curie_prefixes, normalize_message
 from .redis_adapter import RedisConnectionFactory
 from .util import LoggingUtil
+from .examples import EXAMPLE_QUERY_DRUG_TREATS_ESSENTIAL_HYPERTENSION
 
 logger = LoggingUtil.init_logging()
 
@@ -98,7 +99,10 @@ async def shutdown_event():
     response_model_exclude_none=True,
     response_model_exclude_unset=True
 )
-async def query(query: reasoner_pydantic.Query) -> reasoner_pydantic.Query:
+async def query(query: Annotated[reasoner_pydantic.Query, Body(openapi_examples={"Drugs that treat essential hypertension": {
+    "summary": "A result from a query for drugs that treat essential hypertension.",
+    "value": EXAMPLE_QUERY_DRUG_TREATS_ESSENTIAL_HYPERTENSION,
+}})]) -> reasoner_pydantic.Query:
     """
     Normalizes a TRAPI compliant knowledge graph
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aioredis~=1.3.1
 click==8.0.4
 bmt-lite-v3.1.0==2.2.2
 deepdiff==5.8.1
-fastapi==0.83.0
+fastapi~=0.108.0
 httptools==0.5.0
 jsonschema~=4.6.0
 pytest==6.2.5


### PR DESCRIPTION
This PR updates the POST /query example, which currently uses a blank example from reasoner_pydantic, which doesn't have any actual effect on the output. This PR modifies that to include the example query we use in PR https://github.com/TranslatorSRI/babel-validation/pull/26, which requires upgrading FastAPI as well.

Once merged, the example screen should look like this:
<img width="1434" alt="Screenshot 2023-12-31 at 3 21 18 PM" src="https://github.com/TranslatorSRI/NodeNormalization/assets/23979/ca0e7b9a-8da5-4bba-95c3-e10aff3800fb">
