### PR TITLE
updating biolink types in api examples

### DIFF
--- a/node_normalizer/model/input.py
+++ b/node_normalizer/model/input.py
@@ -53,6 +53,6 @@ class SemanticTypesInput(BaseModel):
     class Config:
         schema_extra = {
             "example": {
-                "semantic_types": ['biolink:ChemicalSubstance', 'biolink:AnatomicalEntity']
+                "semantic_types": ['biolink:ChemicalEntity', 'biolink:AnatomicalEntity']
             }
         }

--- a/node_normalizer/model/response.py
+++ b/node_normalizer/model/response.py
@@ -15,8 +15,8 @@ class SemanticTypes(BaseModel):
             "example": {
                 "semantic_types": {
                     "types": [
-                        "cellular_component",
-                        "named_thing",
+                        "biolink:CellularComponent",
+                        "biolink:NamedThing",
                         "etc."
                     ]
                 }

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -252,7 +252,8 @@ async def get_semantic_types_handler() -> SemanticTypes:
     description="Returns the curies and their hit count for a semantic type(s).",
 )
 async def get_curie_prefixes_handler(
-    semantic_type: Optional[List[str]] = fastapi.Query([], description="e.g. chemical_substance, anatomical_entity")
+    semantic_type: Optional[List[str]] = fastapi.Query([], description="e.g. biolink:ChemicalEntity, "
+                                                                       "biolink:AnatomicalEntity")
 ) -> Dict[str, CuriePivot]:
     return await get_curie_prefixes(app, semantic_type)
 


### PR DESCRIPTION
These examples/description were no longer valid, the biolink:xxx format matches the current functionality.