### PR TITLE
Add a status endpoint with database name, key count and memory usage for each database

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: 'Publish to GitHub Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: 'Publish to GitHub Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/node_normalizer/redis_adapter.py
+++ b/node_normalizer/redis_adapter.py
@@ -115,6 +115,24 @@ class RedisConnection:
             self.connector: aioredis.commands.Redis
             return await self.connector.dbsize()
 
+    async def info(self, section):
+        """
+        :return: The info of this Redis database.
+        """
+        if isinstance(self.connector, RedisCluster):
+            self.connector: RedisCluster
+            return self.connector.info(section)
+        elif isinstance(self.connector, aioredis.commands.Redis):
+            self.connector: aioredis.commands.Redis
+            return await self.connector.info(section)
+
+    async def used_memory_rss_human(self):
+        """
+        :return: The used memory in human units (e.g. 66.71G)
+        """
+        return (await self.info('memory')).get('memory').get('used_memory_rss_human')
+
+
     def close(self):
         """
         Close underlying connection.

--- a/node_normalizer/redis_adapter.py
+++ b/node_normalizer/redis_adapter.py
@@ -104,6 +104,17 @@ class RedisConnection:
             self.connector: aioredis.commands.Redis
             return await self.connector.get(key, encoding=encoding)
 
+    async def dbsize(self):
+        """
+        :return: The number of keys in this Redis database.
+        """
+        if isinstance(self.connector, RedisCluster):
+            self.connector: RedisCluster
+            return self.connector.dbsize()
+        elif isinstance(self.connector, aioredis.commands.Redis):
+            self.connector: aioredis.commands.Redis
+            return await self.connector.dbsize()
+
     def close(self):
         """
         Close underlying connection.

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -117,37 +117,37 @@ async def status() -> Dict:
         "databases": {
             "eq_id_to_id_db": {
                 "dbname": "id-id",
-                "count": await app.state.redis_connection0.dbsize(),
+                "count": await app.state.eq_id_to_id_db.dbsize(),
                 "is_cluster": redis_config['eq_id_to_id_db'].get('is_cluster', 'false')
             },
             "id_to_eqids_db": {
                 "dbname": "id-eq-id",
-                "count": await app.state.redis_connection1.dbsize(),
+                "count": await app.state.id_to_eqids_db.dbsize(),
                 "is_cluster": redis_config['id_to_eqids_db'].get('is_cluster', 'false')
             },
             "id_to_type_db": {
                 "dbname": "id-categories",
-                "count": await app.state.redis_connection2.dbsize(),
+                "count": await app.state.id_to_type_db.dbsize(),
                 "is_cluster": redis_config['id_to_type_db'].get('is_cluster', 'false')
             },
             "curie_to_bl_type_db": {
                 "dbname": "semantic-count",
-                "count": await app.state.redis_connection3.dbsize(),
+                "count": await app.state.curie_to_bl_type_db.dbsize(),
                 "is_cluster": redis_config['curie_to_bl_type_db'].get('is_cluster', 'false')
             },
             "info_content_db": {
                 "dbname": "info-content",
-                "count": await app.state.redis_connection4.dbsize(),
+                "count": await app.state.info_content_db.dbsize(),
                 "is_cluster": redis_config['info_content_db'].get('is_cluster', 'false')
             },
             "gene_protein_db": {
                 "dbname": "conflation-db",
-                "count": await app.state.redis_connection5.dbsize(),
+                "count": await app.state.gene_protein_db.dbsize(),
                 "is_cluster": redis_config['gene_protein_db'].get('is_cluster', 'false')
             },
             "chemical_drug_db": {
                 "dbname": "chemical-drug-db",
-                "count": await app.state.redis_connection6.dbsize(),
+                "count": await app.state.chemical_drug_db.dbsize(),
                 "is_cluster": redis_config['chemical_drug_db'].get('is_cluster', 'false')
             }
         },

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -118,36 +118,43 @@ async def status() -> Dict:
             "eq_id_to_id_db": {
                 "dbname": "id-id",
                 "count": await app.state.eq_id_to_id_db.dbsize(),
+                "used_memory_rss_human": await app.state.eq_id_to_id_db.used_memory_rss_human(),
                 "is_cluster": redis_config['eq_id_to_id_db'].get('is_cluster', 'false')
             },
             "id_to_eqids_db": {
                 "dbname": "id-eq-id",
                 "count": await app.state.id_to_eqids_db.dbsize(),
+                "used_memory_rss_human": await app.state.id_to_eqids_db.used_memory_rss_human(),
                 "is_cluster": redis_config['id_to_eqids_db'].get('is_cluster', 'false')
             },
             "id_to_type_db": {
                 "dbname": "id-categories",
                 "count": await app.state.id_to_type_db.dbsize(),
+                "used_memory_rss_human": await app.state.id_to_type_db.used_memory_rss_human(),
                 "is_cluster": redis_config['id_to_type_db'].get('is_cluster', 'false')
             },
             "curie_to_bl_type_db": {
                 "dbname": "semantic-count",
                 "count": await app.state.curie_to_bl_type_db.dbsize(),
+                "used_memory_rss_human": await app.state.curie_to_bl_type_db.used_memory_rss_human(),
                 "is_cluster": redis_config['curie_to_bl_type_db'].get('is_cluster', 'false')
             },
             "info_content_db": {
                 "dbname": "info-content",
                 "count": await app.state.info_content_db.dbsize(),
+                "used_memory_rss_human": await app.state.info_content_db.used_memory_rss_human(),
                 "is_cluster": redis_config['info_content_db'].get('is_cluster', 'false')
             },
             "gene_protein_db": {
                 "dbname": "conflation-db",
                 "count": await app.state.gene_protein_db.dbsize(),
+                "used_memory_rss_human": await app.state.gene_protein_db.used_memory_rss_human(),
                 "is_cluster": redis_config['gene_protein_db'].get('is_cluster', 'false')
             },
             "chemical_drug_db": {
                 "dbname": "chemical-drug-db",
                 "count": await app.state.chemical_drug_db.dbsize(),
+                "used_memory_rss_human": await app.state.chemical_drug_db.used_memory_rss_human(),
                 "is_cluster": redis_config['chemical_drug_db'].get('is_cluster', 'false')
             }
         },

--- a/redis_config.yaml
+++ b/redis_config.yaml
@@ -11,7 +11,7 @@
 "id_to_eqids_db":
   "ssl_enabled": false
   "is_cluster": false
-  "db": 0
+  "db": 1
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"
@@ -20,7 +20,7 @@
 "id_to_type_db":
   "ssl_enabled": false
   "is_cluster": false
-  "db": 0
+  "db": 2
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"
@@ -29,7 +29,7 @@
 "curie_to_bl_type_db":
   "ssl_enabled": false
   "is_cluster": false
-  "db": 0
+  "db": 3
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"
@@ -38,7 +38,7 @@
 "gene_protein_db":
   "ssl_enabled": false
   "is_cluster": false
-  "db": 0
+  "db": 4
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"
@@ -56,7 +56,7 @@
 "info_content_db":
   "ssl_enabled": false
   "is_cluster": false
-  "db": 0
+  "db": 5
   "hosts":
     - "host_name": "127.0.0.1"
       "port": "6379"


### PR DESCRIPTION
This PR adds a `/status` endpoint that returns a bunch of information about the databases this NodeNorm instance is connected to. Here is what it currently returns for 2024aug18:

```json
{
  "status": "running",
  "databases": {
    "eq_id_to_id_db": {
      "dbname": "id-id",
      "count": 662155521,
      "used_memory_rss_human": "67.50G",
      "is_cluster": false
    },
    "id_to_eqids_db": {
      "dbname": "id-eq-id",
      "count": 475350787,
      "used_memory_rss_human": "106.66G",
      "is_cluster": false
    },
    "id_to_type_db": {
      "dbname": "id-categories",
      "count": 475350787,
      "used_memory_rss_human": "44.76G",
      "is_cluster": false
    },
    "curie_to_bl_type_db": {
      "dbname": "semantic-count",
      "count": 134,
      "used_memory_rss_human": "13.87M",
      "is_cluster": false
    },
    "info_content_db": {
      "dbname": "info-content",
      "count": 3346582,
      "used_memory_rss_human": "212.19M",
      "is_cluster": false
    },
    "gene_protein_db": {
      "dbname": "conflation-db",
      "count": 21431316,
      "used_memory_rss_human": "3.93G",
      "is_cluster": false
    },
    "chemical_drug_db": {
      "dbname": "chemical-drug-db",
      "count": 102852,
      "used_memory_rss_human": "159.74M",
      "is_cluster": false
    }
  }
}
```