### PR TITLE
Updated TRAPI version to 1.5.0

### DIFF
--- a/node_normalizer/resources/openapi.yml
+++ b/node_normalizer/resources/openapi.yml
@@ -26,7 +26,7 @@ info:
       - Standards Reference Implementation Team
     infores: "infores:sri-node-normalizer"
   x-trapi:
-    version: 1.4.0
+    version: 1.5.0
     operations:
       - annotate_nodes
 

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -47,7 +47,7 @@ loader = NodeLoader()
 
 redis_host = os.environ.get("REDIS_HOST", loader.get_config()["redis_host"])
 redis_port = os.environ.get("REDIS_PORT", loader.get_config()["redis_port"])
-TRAPI_VERSION = os.environ.get("TRAPI_VERSION", "1.4")
+TRAPI_VERSION = os.environ.get("TRAPI_VERSION", "1.5")
 
 async_query_tasks = set()
 


### PR DESCRIPTION
As per https://github.com/TranslatorSRI/NodeNormalization/issues/266#issuecomment-2183051908, this upgrades the TRAPI version to 1.5.0 without moving the endpoints into the app. Closes #254.