### PR TITLE
Change default TRAPI version for URL to 1.5

### DIFF
--- a/node_normalizer/apidocs.py
+++ b/node_normalizer/apidocs.py
@@ -71,7 +71,7 @@ def construct_open_api_schema(app) -> Dict[str, str]:
     if 'servers' in api_docs:
         for s in api_docs['servers']:
             # override if server root env var is provided
-            s['url'] = server_root + os.environ.get("TRAPI_VERSION", "1.4") if server_root != '/' else s['url']
+            s['url'] = server_root + os.environ.get("TRAPI_VERSION", "1.5") if server_root != '/' else s['url']
             s['x-maturity'] = os.environ.get("MATURITY_VALUE", "maturity")
             s['x-location'] = os.environ.get("LOCATION_VALUE", "location")
         open_api_schema['servers'] = api_docs['servers']

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -47,7 +47,6 @@ loader = NodeLoader()
 
 redis_host = os.environ.get("REDIS_HOST", loader.get_config()["redis_host"])
 redis_port = os.environ.get("REDIS_PORT", loader.get_config()["redis_port"])
-TRAPI_VERSION = os.environ.get("TRAPI_VERSION", "1.5")
 
 async_query_tasks = set()
 


### PR DESCRIPTION
The previous PR (#269) replaced the TRAPI version in the wrong location. This PR fixes that, and properly upgrades the TRAPI version to 1.5.0 without moving the endpoints into the app. Closes #254.