### PR TITLE
Add POST SetID

### DIFF
--- a/node_normalizer/model/__init__.py
+++ b/node_normalizer/model/__init__.py
@@ -2,5 +2,5 @@
 API Models not described in reasoner-pydantic
 """
 
-from .input import CurieList, SemanticTypesInput
+from .input import CurieList, SemanticTypesInput, SetIDQuery
 from .response import CuriePivot, SemanticTypes, ConflationList, SetIDResponse

--- a/node_normalizer/model/input.py
+++ b/node_normalizer/model/input.py
@@ -4,7 +4,7 @@ API Input Models not described in reasoner-pydantic
 
 from pydantic import BaseModel, Field
 
-from typing import List
+from typing import List, Dict
 
 
 class CurieList(BaseModel):
@@ -61,3 +61,26 @@ class SemanticTypesInput(BaseModel):
                 "semantic_types": ['biolink:ChemicalEntity', 'biolink:AnatomicalEntity']
             }
         }
+
+
+class SetIDQuery(BaseModel):
+    """ Query for a single SetID. Includes a set of CURIEs as well as a set of conflations to apply. """
+
+    curies: List[str] = Field(
+        ...,  # Ellipsis means field is required
+        description="Set of curies to normalize",
+        example=["MESH:D014867", "NCIT:C34373"],
+    )
+
+    conflations: List[str] = Field(
+        [],
+        description="Set of conflations to apply",
+        example=["GeneProtein", "DrugChemical"],
+    )
+
+
+class SetIDs(BaseModel):
+    """ Query for Set IDs. You can provide a set of named CURIE sets, and we return a response for each one. """
+    sets: Dict[str, SetIDQuery] = Field(
+        description="A list of ",
+    )

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -255,7 +255,7 @@ async def get_setid(
     summary="Normalize and deduplicate a set of identifiers and return a single hash that represents this set."
 )
 async def get_setid(
-    sets: Dict[str, SetIDQuery] = fastapi.Body({},
+    sets: List[SetIDQuery] = fastapi.Body([],
                                                 description="Set of identifiers to normalize",
                                                 example=[
                                                     {
@@ -266,7 +266,7 @@ async def get_setid(
                                                         "conflations": ["GeneProtein", "DrugChemical"]
                                                     }
                                                 ])
-) -> Dict[str, SetIDResponse]:
+) -> List[SetIDResponse]:
     # I'm guessing there's some way of doing this so that the generate_setid()s run in parallel, but I don't know how.
     # I'll figure it out if needed.
     return [await generate_setid(app, q.curies, q.conflations) for q in sets]

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -251,25 +251,25 @@ async def get_setid(
 
 @app.post(
     "/get_setid",
-    response_model=Dict[str, SetIDResponse],
+    response_model=List[SetIDResponse],
     summary="Normalize and deduplicate a set of identifiers and return a single hash that represents this set."
 )
 async def get_setid(
     sets: Dict[str, SetIDQuery] = fastapi.Body({},
                                                 description="Set of identifiers to normalize",
-                                                example={
-                                                    "set1": {
+                                                example=[
+                                                    {
                                                         "curies": ["MESH:D014867", "NCIT:C34373"],
                                                     },
-                                                    "set2": {
+                                                    {
                                                         "curies": ["NCIT:C34373", "MESH:D014867", "UNII:63M8RYN44N", "RUBBISH:1234" ],
                                                         "conflations": ["GeneProtein", "DrugChemical"]
                                                     }
-                                                })
+                                                ])
 ) -> Dict[str, SetIDResponse]:
     # I'm guessing there's some way of doing this so that the generate_setid()s run in parallel, but I don't know how.
     # I'll figure it out if needed.
-    return {k: await generate_setid(app, q.curies, q.conflations) for k, q in sets.items()}
+    return [await generate_setid(app, q.curies, q.conflations) for q in sets]
 
 
 @app.get(

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -267,6 +267,8 @@ async def get_setid(
                                                     }
                                                 })
 ) -> Dict[str, SetIDResponse]:
+    # I'm guessing there's some way of doing this so that the generate_setid()s run in parallel, but I don't know how.
+    # I'll figure it out if needed.
     return {k: await generate_setid(app, q.curies, q.conflations) for k, q in sets.items()}
 
 

--- a/tests/test_setid.py
+++ b/tests/test_setid.py
@@ -107,7 +107,7 @@ def test_setid_basic():
         }
     ]
 
-    for key, expected_setid in expected_setids.items():
+    for expected_setid in expected_setids:
         response = client.get("/get_setid", params={
             'curie': expected_setid['curie'],
             'conflation': expected_setid['conflation'],
@@ -120,7 +120,7 @@ def test_setid_basic():
         assert result['setid'] == expected_setid['setid']
 
     # Test all of them at once using the 'POST' interface.
-    setid_query = [{'curies': v['curie'], 'conflations': v['conflation']} for k, v in expected_setids.items()]
+    setid_query = [{'curies': e['curie'], 'conflations': e['conflation']} for e in expected_setids]
     response = client.post("/get_setid", json=setid_query)
     results = response.json()
     for index, result in enumerate(results):

--- a/tests/test_setid.py
+++ b/tests/test_setid.py
@@ -107,7 +107,7 @@ def test_setid_basic():
         }
     }
 
-    for key, expected_setid in expected_setids:
+    for key, expected_setid in expected_setids.items():
         response = client.get("/get_setid", params={
             'curie': expected_setid['curie'],
             'conflation': expected_setid['conflation'],
@@ -123,7 +123,7 @@ def test_setid_basic():
     setid_query = {k: {'curies': v['curie'], 'conflations': v['conflation']} for k, v in expected_setids.items()}
     response = client.post("/get_setid", json=setid_query)
     results = response.json()
-    for key, result in results:
+    for key, result in results.items():
         expected_setid = expected_setids[key]
 
         assert result['error'] is None

--- a/tests/test_setid.py
+++ b/tests/test_setid.py
@@ -80,8 +80,8 @@ def test_setid_basic():
     """
     client = TestClient(app)
 
-    expected_setids = [
-        {
+    expected_setids = {
+        '1': {
             'curie': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
             'conflation': ['GeneProtein'],
             'curies': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
@@ -89,7 +89,7 @@ def test_setid_basic():
             'normalized_string': '||MONDO:0005002||MONDO:0005003||PUBCHEM.COMPOUND:10129877',
             'setid': 'uuid:08da0da0-4b47-55e6-b9b2-73ead9921494'
         },
-        {
+        '2': {
             'curie': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
             'conflation': ['GeneProtein', 'DrugChemical'],
             'curies': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
@@ -97,7 +97,7 @@ def test_setid_basic():
             'normalized_string': '||CHEBI:15377||MONDO:0005002||MONDO:0005003',
             'setid': 'uuid:4b54135a-a151-561b-8b25-8a5a5b710700'
         },
-        {
+        '3': {
             'curie': ['!#lk1l4', '09s90ma!:391nasa01AAa', 10.31, 9018, -913],
             'conflation': ['GeneProtein', 'DrugChemical'],
             'curies': ['!#lk1l4', '09s90ma!:391nasa01AAa', '10.31', '9018', '-913'],
@@ -105,15 +105,27 @@ def test_setid_basic():
             'normalized_string': '!#lk1l4||-913||09s90ma!:391nasa01AAa||10.31||9018',
             'setid': 'uuid:2fe78021-4a98-53cc-b911-a55962575095'
         }
-    ]
+    }
 
-    for expected_setid in expected_setids:
+    for key, expected_setid in expected_setids:
         response = client.get("/get_setid", params={
             'curie': expected_setid['curie'],
             'conflation': expected_setid['conflation'],
         })
         result = response.json()
         assert result['curies'] == expected_setid['curies']
+        assert result['error'] is None
+        assert result['normalized_curies'] == expected_setid['normalized_curies']
+        assert result['normalized_string'] == expected_setid['normalized_string']
+        assert result['setid'] == expected_setid['setid']
+
+    # Test all of them at once using the 'POST' interface.
+    setid_query = {k: {'curies': v['curie'], 'conflations': v['conflation']} for k, v in expected_setids.items()}
+    response = client.post("/get_setid", json=setid_query)
+    results = response.json()
+    for key, result in results:
+        expected_setid = expected_setids[key]
+
         assert result['error'] is None
         assert result['normalized_curies'] == expected_setid['normalized_curies']
         assert result['normalized_string'] == expected_setid['normalized_string']

--- a/tests/test_setid.py
+++ b/tests/test_setid.py
@@ -80,8 +80,8 @@ def test_setid_basic():
     """
     client = TestClient(app)
 
-    expected_setids = {
-        '1': {
+    expected_setids = [
+        {
             'curie': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
             'conflation': ['GeneProtein'],
             'curies': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
@@ -89,7 +89,7 @@ def test_setid_basic():
             'normalized_string': '||MONDO:0005002||MONDO:0005003||PUBCHEM.COMPOUND:10129877',
             'setid': 'uuid:08da0da0-4b47-55e6-b9b2-73ead9921494'
         },
-        '2': {
+        {
             'curie': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
             'conflation': ['GeneProtein', 'DrugChemical'],
             'curies': ['DOID:3812', 'MONDO:0005002', 'MONDO:0005003', 'UNII:63M8RYN44N', ''],
@@ -97,7 +97,7 @@ def test_setid_basic():
             'normalized_string': '||CHEBI:15377||MONDO:0005002||MONDO:0005003',
             'setid': 'uuid:4b54135a-a151-561b-8b25-8a5a5b710700'
         },
-        '3': {
+        {
             'curie': ['!#lk1l4', '09s90ma!:391nasa01AAa', 10.31, 9018, -913],
             'conflation': ['GeneProtein', 'DrugChemical'],
             'curies': ['!#lk1l4', '09s90ma!:391nasa01AAa', '10.31', '9018', '-913'],
@@ -105,7 +105,7 @@ def test_setid_basic():
             'normalized_string': '!#lk1l4||-913||09s90ma!:391nasa01AAa||10.31||9018',
             'setid': 'uuid:2fe78021-4a98-53cc-b911-a55962575095'
         }
-    }
+    ]
 
     for key, expected_setid in expected_setids.items():
         response = client.get("/get_setid", params={
@@ -120,11 +120,11 @@ def test_setid_basic():
         assert result['setid'] == expected_setid['setid']
 
     # Test all of them at once using the 'POST' interface.
-    setid_query = {k: {'curies': v['curie'], 'conflations': v['conflation']} for k, v in expected_setids.items()}
+    setid_query = [{'curies': v['curie'], 'conflations': v['conflation']} for k, v in expected_setids.items()]
     response = client.post("/get_setid", json=setid_query)
     results = response.json()
-    for key, result in results.items():
-        expected_setid = expected_setids[key]
+    for index, result in enumerate(results):
+        expected_setid = expected_setids[index]
 
         assert result['error'] is None
         assert result['normalized_curies'] == expected_setid['normalized_curies']


### PR DESCRIPTION
This PR adds a POST SetID endpoint that allows you to submit multiple CURIE sets simultaneously, and get them all back at once. It also adds a test for this new endpoint.

Closes #283.