### PR TITLE
upgrading otel implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ orjson==3.9.15
 httpx==0.23.0
 
 # To support Open Telemetry
-opentelemetry-sdk==1.21.0
-opentelemetry-exporter-jaeger==1.21.0
-opentelemetry-instrumentation-fastapi==0.42b0
-opentelemetry-instrumentation-httpx==0.42b0
+opentelemetry-sdk==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-httpx==0.48b0


### PR DESCRIPTION
JaegerExporter is deprecated and the thrift protocol it uses causes issues due to the UDP packet size limitations. This uses OTLP over gRPC instead.