### PR TITLE
Add Babel version to /status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: 'Publish to GitHub Packages'
 
 on:
+    push:
     release:
         types: [published]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: 'Publish to GitHub Packages'
 
 on:
-    push:
     release:
         types: [published]
 

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -112,12 +112,14 @@ async def status() -> Dict:
         # Load rcfile as a YAML file using safe loading.
         redis_config = yaml.safe_load(rcfile)
 
-    # Do we know the Babel version? It will be stored in an environmental variable if we do.
+    # Do we know the Babel version and version URL? It will be stored in an environmental variable if we do.
     babel_version = os.environ.get("BABEL_VERSION", "unknown")
+    babel_version_url = os.environ.get("BABEL_VERSION_URL", "")
 
     return {
         "status": "running",
         "babel_version": babel_version,
+        "babel_version_url": babel_version_url,
         "databases": {
             "eq_id_to_id_db": {
                 "dbname": "id-id",

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -112,8 +112,12 @@ async def status() -> Dict:
         # Load rcfile as a YAML file using safe loading.
         redis_config = yaml.safe_load(rcfile)
 
+    # Do we know the Babel version? It will be stored in an environmental variable if we do.
+    babel_version = os.environ.get("BABEL_VERSION", "unknown")
+
     return {
         "status": "running",
+        "babel_version": babel_version,
         "databases": {
             "eq_id_to_id_db": {
                 "dbname": "id-id",


### PR DESCRIPTION
This PR adds the Babel version of the current release to the output of the `/status` endpoint, but only if the `BABEL_VERSION` environmental variable has been set -- ideally, we would read this off the database, but I can't think of a reasonably non-hacky way of doing this before we get a property store set up, but this should help in the meantime. There is also a `BABEL_VERSION_URL`, which we can use to point to the release notes.