### PR TITLE
Added release notes for NodeNorm v2.3.19 and v2.3.25

### DIFF
--- a/releases/v2.3.19.md
+++ b/releases/v2.3.19.md
@@ -3,7 +3,7 @@
   ([Babel 2025jan23](https://github.com/TranslatorSRI/Babel/blob/master/releases/2025jan23.md))
 - NodeNorm: [v2.3.19](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.19)
 
-Next release: _None as yet_
+Next release: [v2.3.25](./v2.3.25.md)
 Previous release: [Translator "Hammerhead" November 2024](./TranslatorHammerheadNovember2024.md)
 
 ## New features

--- a/releases/v2.3.25.md
+++ b/releases/v2.3.25.md
@@ -1,0 +1,37 @@
+# NodeNorm v2.3.25
+- Babel: [2025sep1](https://stars.renci.org/var/babel_outputs/2025sep1/)
+  ([Babel 2025sep1](https://github.com/TranslatorSRI/Babel/blob/master/releases/2025sep1.md))
+- NodeNorm: [v2.3.25](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.25)
+
+Next release: _None as yet_
+Previous release: [v2.3.19](./v2.3.19.md)
+
+## New features
+* The Babel version is now included in the `/status` endpoint (PR #315).
+* Added logging of normalization so we can benchmark NodeNorm (PR #312).
+* The `/query` and `/asyncquery` endpoints are now deprecated (PR #323).
+
+## Updates
+* Improved documentation.
+* Added release notes for November 2024 and January 2025.
+* Updated renci-python-image to GitHub Packages.
+
+## Babel updates (from [Babel 2025jan23](https://github.com/TranslatorSRI/Babel/blob/master/releases/2025jan23.md))
+- TBD
+
+## Releases since [NodeNorm v2.3.19](./v2.3.19.md)
+* [NodeNorm v2.3.20](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.20)
+  * Add release info for November 2024 and January 2025 by @gaurav in #308
+  * Bump gunicorn from 22.0.0 to 23.0.0 by @dependabot in #310
+* [NodeNorm v2.3.21](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.21)
+  * Incremented version (forgot to do that in the previous release).
+* [NodeNorm v2.3.22](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.22)
+  * Added normalization logging by @gaurav in #312
+* [NodeNorm v2.3.23](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.23)
+  * Add Babel version to /status by @gaurav in #315
+* [NodeNorm v2.3.24](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.24)
+  * Deprecated TRAPI methods (/query and /asyncquery) by @gaurav in #323 
+  * Added API documentation by @gaurav in #322 
+  * Updated RENCI Python Image in Dockerfile.
+* [NodeNorm v2.3.25](https://github.com/TranslatorSRI/NodeNormalization/releases/tag/v2.3.25)
+  * Removed unused/invalid imports.


### PR DESCRIPTION
This PR adds release notes for NodeNorm v2.3.19 and v2.3.25.

WIP: I need to add the Babel release notes.